### PR TITLE
Include migrations table when copying databases

### DIFF
--- a/drizzle/schema/migrations.ts
+++ b/drizzle/schema/migrations.ts
@@ -2,7 +2,9 @@ import { pgSchema } from "drizzle-orm/pg-core";
 import { varchar } from "drizzle-orm/pg-core";
 import { serial, char, timestamp } from "drizzle-orm/pg-core";
 
-export const Migration = pgSchema("adacta_migrations").table("Migration", {
+export const MIGRATION_SCHEMA_NAME = "adacta_migrations";
+
+export const Migration = pgSchema(MIGRATION_SCHEMA_NAME).table("Migration", {
 	id: serial("migration_id").primaryKey().notNull(),
 
 	/**

--- a/scripts/copy-repos.ts
+++ b/scripts/copy-repos.ts
@@ -9,6 +9,7 @@ import { S3Config } from "~/apps/repo-server/src/config/S3Config";
 import { RepositoryManagerPostgres } from "~/apps/repo-server/src/services/RepositoryManagerPostgres";
 import { sh } from "~/dev/sh";
 import { DrizzleGlobalSchema } from "~/drizzle/DrizzleSchema";
+import { MIGRATION_SCHEMA_NAME } from "~/drizzle/schema/migrations";
 import { parseEnvFile } from "~/lib/utils/parseEnvFile";
 
 const rmp: RepositoryManagerPostgres[] = [];
@@ -116,7 +117,11 @@ async function main(args: string[]) {
 	const globalSchemaName = new DrizzleGlobalSchema().global.schemaName;
 	await rmpTarget.db().execute(sql.raw(`drop schema if exists "${globalSchemaName}" cascade;`));
 
-	const schemaArgs = [globalSchemaName, ...repos.map((repo) => rmpSource.schemaName(repo))]
+	const schemaArgs = [
+		MIGRATION_SCHEMA_NAME,
+		globalSchemaName,
+		...repos.map((repo) => rmpSource.schemaName(repo)),
+	]
 		.map((n) => `--schema="${n}"`)
 		.join(" ");
 


### PR DESCRIPTION
This pull request fixes an issue in the `copy-repos.ts` script where the migrations table was not included in the copy process. As a result, previously executed migrations were being rerun.