### PR TITLE
Fix quick access bar

### DIFF
--- a/apps/desktop-app/src/components/welcome/HistoryList.tsx
+++ b/apps/desktop-app/src/components/welcome/HistoryList.tsx
@@ -69,10 +69,10 @@ interface IProps {
 }
 
 function HistoryListRaw({ ids, favorites }: IProps) {
-	const data = useLazyLoadQuery<HistoryListQuery>(HistoryListGraphQLQuery, {
-		ids: ids.map((i) => i.id),
-	});
 	const repositoryId = useRepositoryIdMaybe();
+	const data = useLazyLoadQuery<HistoryListQuery>(HistoryListGraphQLQuery, {
+		ids: ids.filter((i) => i.repositoryId === repositoryId).map((i) => i.id),
+	});
 
 	if (!repositoryId) {
 		return (

--- a/scripts/copy-repos.ts
+++ b/scripts/copy-repos.ts
@@ -116,6 +116,9 @@ async function main(args: string[]) {
 	);
 	const globalSchemaName = new DrizzleGlobalSchema().global.schemaName;
 	await rmpTarget.db().execute(sql.raw(`drop schema if exists "${globalSchemaName}" cascade;`));
+	await rmpTarget
+		.db()
+		.execute(sql.raw(`drop schema if exists "${MIGRATION_SCHEMA_NAME}" cascade;`));
 
 	const schemaArgs = [
 		MIGRATION_SCHEMA_NAME,


### PR DESCRIPTION
This PR prevents the app from crashing when a user who has multiple repositories defined attempts to access the quick access bar.

This was done by only showing items in the quick access bar that exist in the currently selected repository.