### PR TITLE
Fix "0 is read-only" crash when editing device definition

### DIFF
--- a/apps/desktop-app/src/components/specifications/SpecificationEditor.tsx
+++ b/apps/desktop-app/src/components/specifications/SpecificationEditor.tsx
@@ -176,7 +176,7 @@ const SpecificationEditor = forwardRef<
 
 	// Create a list of all specifications with the possibility to edit them as required
 	// for the DescriptionList
-	const existingSpecificationsItems = props.specifications
+	const existingSpecificationsItems = [...props.specifications]
 		.sort((a, b) => a.name.localeCompare(b.name))
 		.map((s) => {
 			const updateSpecification = () => {


### PR DESCRIPTION
PR #4 introduced a change that mistakenly mutated props.
This caused the device definition editor to crash when adding a new specification.