### PR TITLE
Simplify DeviceList DOM to avoid rendering issues on Firefox

### DIFF
--- a/apps/desktop-app/src/components/device/list/hierarchical/DeviceListHierarchical.tsx
+++ b/apps/desktop-app/src/components/device/list/hierarchical/DeviceListHierarchical.tsx
@@ -193,10 +193,8 @@ export function DeviceListHierarchical(props: {
 							/>
 						) : null
 					)}
-				</EuiTableBody>
-				{/* This is a hack to make the border thicker */}
-				<td colSpan={2} style={{ borderWidth: "thick" }} />{" "}
-				<EuiTableBody>
+					{/* This is a hack to make the border thicker */}
+					<td colSpan={2} style={{ borderWidth: "thick" }} />{" "}
 					{toplevelDevices.map((d, i) =>
 						d.node ? (
 							<HierarchicalDeviceTableRowToplevel


### PR DESCRIPTION
The borders of the table rows where missing on Firefox.
With a simplified structure this issue is gone.