### PR TITLE
Various UI improvements/fixes

### DIFF
--- a/apps/desktop-app/src/components/FileUpload.tsx
+++ b/apps/desktop-app/src/components/FileUpload.tsx
@@ -154,12 +154,12 @@ function FileUploadProjects(props: {
 			aria-label="Assign projects to resource"
 			placeholder="Select projects this resource belongs to"
 			options={options}
-			onChange={(o) => {
-				const ids = o.flatMap((id) => {
-					if (!id.value) {
+			onChange={(selectedOptions) => {
+				const ids = selectedOptions.flatMap((option) => {
+					if (!option.value) {
 						return [];
 					}
-					return id.value;
+					return option.value;
 				});
 
 				setSelectedProjects(ids);

--- a/apps/desktop-app/src/components/FileUpload.tsx
+++ b/apps/desktop-app/src/components/FileUpload.tsx
@@ -102,10 +102,7 @@ export function FileUpload(props: IProps) {
 	return (
 		<EuiPanel>
 			<div style={{ width: 300, position: "relative" }}>
-				<EuiFormRow
-					label={"Projects"}
-					helpText={"Optional, select projects to assign to the resource"}
-				>
+				<EuiFormRow label={"Projects"} helpText={"Project assignment is optional"}>
 					<FileUploadProjects
 						selectedProjects={selectedProjects}
 						setSelectedProjects={setSelectedProjects}

--- a/apps/desktop-app/src/components/FileUpload.tsx
+++ b/apps/desktop-app/src/components/FileUpload.tsx
@@ -1,13 +1,14 @@
-import { EuiFilePicker, EuiFormRow, EuiPanel } from "@elastic/eui";
+import { EuiComboBox, EuiFilePicker, EuiFormRow, EuiPanel } from "@elastic/eui";
 import React, { useState } from "react";
 import type { GraphQLTaggedNode } from "react-relay";
-import { graphql, useMutation } from "react-relay";
+import { graphql, useLazyLoadQuery, useMutation } from "react-relay";
 
 import { useRepoRouterHook } from "../services/router/RepoRouterHook";
 import { useRepositoryIdVariable } from "../services/router/UseRepoId";
 import { uploadFileBrowser } from "../utils/uploadFileBrowser";
 
 import type { FileUploadMutation } from "@/relay/FileUploadMutation.graphql";
+import type { FileUploadProjectsQuery } from "@/relay/FileUploadProjectsQuery.graphql";
 import type { FileUploadRequestMutation } from "@/relay/FileUploadRequestMutation.graphql";
 import type { IDeviceId } from "~/lib/database/Ids";
 
@@ -32,6 +33,8 @@ const FileUploadGraphQLMutation: GraphQLTaggedNode = graphql`
 
 interface IProps {
 	deviceId: IDeviceId;
+
+	defaultProjects?: string[];
 }
 
 export function FileUpload(props: IProps) {
@@ -44,11 +47,17 @@ export function FileUpload(props: IProps) {
 	);
 
 	const [importRawResourceMutation] = useMutation<FileUploadMutation>(FileUploadGraphQLMutation);
+	const [selectedProjects, setSelectedProjects] = useState<string[]>(props.defaultProjects ?? []);
 
 	const importRawResource = (uploadId: string, filename: string) => {
 		importRawResourceMutation({
 			variables: {
-				input: { uploadDevice: props.deviceId, uploadId: uploadId, name: filename },
+				input: {
+					uploadDevice: props.deviceId,
+					uploadId: uploadId,
+					name: filename,
+					projects: selectedProjects,
+				},
 				...repositoryIdVariable,
 			},
 			onCompleted: (result) => {
@@ -93,6 +102,15 @@ export function FileUpload(props: IProps) {
 	return (
 		<EuiPanel>
 			<div style={{ width: 300, position: "relative" }}>
+				<EuiFormRow
+					label={"Projects"}
+					helpText={"Optional, select projects to assign to the resource"}
+				>
+					<FileUploadProjects
+						selectedProjects={selectedProjects}
+						setSelectedProjects={setSelectedProjects}
+					/>
+				</EuiFormRow>
 				<EuiFormRow label={"File"}>
 					<EuiFilePicker
 						isLoading={uploadInFlight}
@@ -103,5 +121,54 @@ export function FileUpload(props: IProps) {
 				</EuiFormRow>
 			</div>
 		</EuiPanel>
+	);
+}
+
+function FileUploadProjects(props: {
+	selectedProjects: string[];
+	setSelectedProjects: (selectedProject: string[]) => void;
+}) {
+	const { selectedProjects, setSelectedProjects } = props;
+	const repositoryIdVariable = useRepositoryIdVariable();
+	const data = useLazyLoadQuery<FileUploadProjectsQuery>(
+		graphql`
+			query FileUploadProjectsQuery($repositoryId: ID!) {
+				repository(id: $repositoryId) {
+					projects {
+						edges {
+							node {
+								id
+								name
+							}
+						}
+					}
+				}
+			}
+		`,
+		repositoryIdVariable
+	);
+
+	const projects = data.repository.projects.edges.map((e) => e.node);
+	const options = projects.map((p) => ({ label: `${p.name}`, value: p.id }));
+	const selectedOptions = options.filter((o) => selectedProjects.includes(o.value));
+
+	return (
+		<EuiComboBox
+			aria-label="Assign projects to resource"
+			placeholder="Select projects this resource belongs to"
+			options={options}
+			onChange={(o) => {
+				const ids = o.flatMap((id) => {
+					if (!id.value) {
+						return [];
+					}
+					return id.value;
+				});
+
+				setSelectedProjects(ids);
+			}}
+			selectedOptions={selectedOptions}
+			isClearable={true}
+		/>
 	);
 }

--- a/apps/desktop-app/src/components/componentNodeTreeProvider/ComponentNodeTreeProvider.tsx
+++ b/apps/desktop-app/src/components/componentNodeTreeProvider/ComponentNodeTreeProvider.tsx
@@ -102,7 +102,7 @@ type TComponentOutput<TDatasource extends ComponentNodeTreeProviderFragmentDataU
 			readonly component: { readonly __typename: "virtualGroup"; name?: "Test" };
 	  };
 
-function createVirtualGroups<TDatasource extends ComponentNodeTreeProviderFragmentDataUnion>(
+export function createVirtualGroups<TDatasource extends ComponentNodeTreeProviderFragmentDataUnion>(
 	components: TComponentOutput<TDatasource>[]
 ): TComponentOutput<TDatasource>[] {
 	type TComponentBound = TComponentOutput<TDatasource>;
@@ -121,20 +121,25 @@ function createVirtualGroups<TDatasource extends ComponentNodeTreeProviderFragme
 		// If the path changes when splitPropertyNameIntoVirtualGroups is applied then this should
 		// be a virtual group
 		if (newPath.length !== oldPath.length) {
-			const newParentPath = newPath.slice(0, -1);
+			const virtualGroupsCausedByThisSlot: TComponentBound[] = [];
 
-			const identifier = JSON.stringify(newParentPath);
-			if (!virtualGroupsCreated.includes(identifier)) {
-				const virtualGroup: TComponentBound = {
-					pathFromTopLevelDevice: newParentPath,
-					component: { __typename: "virtualGroup" },
-				};
+			// Loop over paths to ensure that all virtual groups are created
+			for (let i = 1; i < newPath.length; i++) {
+				const newParentPath = newPath.slice(0, i);
+				const identifier = JSON.stringify(newParentPath);
+				if (!virtualGroupsCreated.includes(identifier)) {
+					const virtualGroup: TComponentBound = {
+						pathFromTopLevelDevice: newParentPath,
+						component: { __typename: "virtualGroup" },
+					};
 
-				virtualGroupsCreated.push(identifier);
-
-				// Return the virtual group and the component
-				return [c, virtualGroup];
+					virtualGroupsCreated.push(identifier);
+					virtualGroupsCausedByThisSlot.push(virtualGroup);
+				}
 			}
+
+			// Return the virtual group and the component
+			return [c, ...virtualGroupsCausedByThisSlot];
 		}
 
 		return [c];

--- a/apps/desktop-app/src/components/componentNodeTreeProvider/ComponentNodeTreeProvider.tsx
+++ b/apps/desktop-app/src/components/componentNodeTreeProvider/ComponentNodeTreeProvider.tsx
@@ -73,9 +73,14 @@ interface IContext<T extends ComponentNodeTreeProviderFragmentDataUnion> {
 	components: TComponentOutput<ComponentNodeTreeProviderFragment$data>[];
 }
 
-type ComponentNodeTreeProviderFragmentDataUnion =
-	| ComponentNodeTreeProviderFragment$data
-	| DeviceListHierarchicalGraphQLFragment$data;
+type ComponentNodeTreeProviderFragmentDataUnion<TTypes = "Device" | "Sample" | "%other"> = {
+	readonly components: ReadonlyArray<{
+		readonly pathFromTopLevelDevice: ReadonlyArray<string>;
+		readonly component: {
+			__typename: TTypes;
+		};
+	}>;
+};
 
 /**
  * Generic tree structure that different components can wrap however they want.
@@ -99,7 +104,7 @@ type TComponentOutput<TDatasource extends ComponentNodeTreeProviderFragmentDataU
 	| TComponent<TDatasource>
 	| {
 			pathFromTopLevelDevice: string[];
-			readonly component: { readonly __typename: "virtualGroup"; name?: "Test" };
+			readonly component: { readonly __typename: "virtualGroup"; name?: string };
 	  };
 
 export function createVirtualGroups<TDatasource extends ComponentNodeTreeProviderFragmentDataUnion>(

--- a/apps/desktop-app/src/components/componentNodeTreeProvider/ComponentNodeTreeProvider.tsx
+++ b/apps/desktop-app/src/components/componentNodeTreeProvider/ComponentNodeTreeProvider.tsx
@@ -54,6 +54,10 @@ const ComponentNodeTreeProviderFragmentGraphQl = graphql`
 						timestamp
 						timestampEnd
 						name
+						value {
+							# eslint-disable-next-line relay/must-colocate-fragment-spreads
+							...SampleLink
+						}
 					}
 				}
 			}

--- a/apps/desktop-app/src/components/componentNodeTreeProvider/ComponentNodeTreeProvider.tsx
+++ b/apps/desktop-app/src/components/componentNodeTreeProvider/ComponentNodeTreeProvider.tsx
@@ -13,7 +13,6 @@ import type {
 	ComponentNodeTreeProviderFragment$data,
 	ComponentNodeTreeProviderFragment$key,
 } from "@/relay/ComponentNodeTreeProviderFragment.graphql";
-import type { DeviceListHierarchicalGraphQLFragment$data } from "@/relay/DeviceListHierarchicalGraphQLFragment.graphql";
 import { splitPropertyNameIntoVirtualGroups } from "~/lib/utils/splitPropertyNameIntoVirtualGroups";
 
 const ComponentNodeTreeProviderFragmentGraphQl = graphql`

--- a/apps/desktop-app/src/components/componentNodeTreeProvider/__tests__/createVirtualGroups.spec.ts
+++ b/apps/desktop-app/src/components/componentNodeTreeProvider/__tests__/createVirtualGroups.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+
+import { createVirtualGroups } from "~/apps/desktop-app/src/components/componentNodeTreeProvider/ComponentNodeTreeProvider";
+
+const flattenHierarchy = (
+	hierarchy: { pathFromTopLevelDevice: string[] | readonly string[] }[]
+) => {
+	return hierarchy.map((h) => h.pathFromTopLevelDevice.join(" -> ")).sort();
+};
+
+describe("createVirtualGroups", () => {
+	test("should create virtual groups correctly", () => {
+		expect(
+			flattenHierarchy(
+				createVirtualGroups([
+					{ pathFromTopLevelDevice: ["VirtualGroup/Test"], component: { __typename: "Device" } },
+				])
+			)
+		).toMatchInlineSnapshot(`
+			[
+			  "VirtualGroup",
+			  "VirtualGroup -> Test",
+			]
+		`);
+	});
+
+	test("should create nested virtual groups correctly", () => {
+		expect(
+			flattenHierarchy(
+				createVirtualGroups([
+					{
+						pathFromTopLevelDevice: ["VirtualGroup/VirtualSubGroup/Test"],
+						component: { __typename: "Device" },
+					},
+					{
+						pathFromTopLevelDevice: ["VirtualGroup/VirtualSubGroup/Test2"],
+						component: { __typename: "Device" },
+					},
+				])
+			)
+		).toMatchInlineSnapshot(`
+			[
+			  "VirtualGroup",
+			  "VirtualGroup -> VirtualSubGroup",
+			  "VirtualGroup -> VirtualSubGroup -> Test",
+			  "VirtualGroup -> VirtualSubGroup -> Test2",
+			]
+		`);
+	});
+});

--- a/apps/desktop-app/src/components/device/ComponentEuiTree.tsx
+++ b/apps/desktop-app/src/components/device/ComponentEuiTree.tsx
@@ -163,7 +163,6 @@ function ComponentEuiTreePure(props: IPropsPure) {
 					panels={[
 						{
 							id: 0,
-							title: "This is a context menu",
 							items: props.items,
 						},
 					]}

--- a/apps/desktop-app/src/components/device/ComponentEuiTree.tsx
+++ b/apps/desktop-app/src/components/device/ComponentEuiTree.tsx
@@ -243,6 +243,7 @@ function ComponentEuiTreePure(props: IPropsPure) {
 
 			const contextMenuActions: EuiContextMenuPanelItemDescriptor[] = [];
 
+			// Only devices can have children
 			if (node.component.__typename === "Device") {
 				contextMenuActions.push({
 					name: `Add component as child of ${node.component.name}`,
@@ -259,7 +260,10 @@ function ComponentEuiTreePure(props: IPropsPure) {
 						setAddComponentModalOpenForDeviceId(node.component.id);
 					},
 				});
+			}
 
+			// Actions for all components that are not virtual groups
+			if (node.component.__typename !== "virtualGroup") {
 				contextMenuActions.push({
 					name: "Remove component",
 					icon: "minusInCircle",

--- a/apps/desktop-app/src/components/device/ComponentEuiTree.tsx
+++ b/apps/desktop-app/src/components/device/ComponentEuiTree.tsx
@@ -9,7 +9,6 @@ import {
 	EuiFlexGroup,
 	EuiFlexItem,
 	EuiIcon,
-	EuiLoadingSpinner,
 	EuiOverlayMask,
 	EuiPopover,
 	EuiSpacer,
@@ -18,7 +17,6 @@ import {
 } from "@elastic/eui";
 import type { EuiContextMenuPanelItemDescriptor } from "@elastic/eui/src/components/context_menu/context_menu";
 import type { Node } from "@elastic/eui/src/components/tree_view/tree_view";
-import type { MouseEventHandler } from "react";
 import React, { useState } from "react";
 import type { GraphQLTaggedNode } from "react-relay";
 import { graphql, useMutation } from "react-relay";
@@ -122,8 +120,9 @@ function ComponentEuiTreePure(props: IPropsPure) {
 
 	const repositoryIdVariable = useRepositoryIdVariable();
 
-	const [commitRemoveComponents, removeComponentsMutationInFlight] =
-		useMutation<ComponentEuiTreeRemoveComponentMutation>(RemoveComponentGraphQLMutation);
+	const [commitRemoveComponents] = useMutation<ComponentEuiTreeRemoveComponentMutation>(
+		RemoveComponentGraphQLMutation
+	);
 
 	const [addComponentModalOpenForDeviceId, setAddComponentModalOpenForDeviceId] = useState<
 		string | undefined
@@ -308,129 +307,6 @@ function ComponentEuiTreePure(props: IPropsPure) {
 					},
 				});
 			}
-
-			// const actions =
-			// 	node.component.__typename === "virtualGroup" ? (
-			// 		<></>
-			// 	) : (
-			// 		<>
-			// 			{node.component.__typename === "Device" && (
-			// 				<EuiFlexItem grow={false}>
-			// 					<EuiToolTip content={`Add a component to ${node.name} slot.`}>
-			// 						<div
-			// 							className="euiButtonIcon euiButtonIcon--success euiButtonIcon--empty euiButtonIcon--xSmall"
-			// 							onClick={(e) => {
-			// 								// This div acts as a button (plus icon) inside
-			// 								// another button (row of the tree component). To
-			// 								// avoid a click on the tree element the propagation
-			// 								// has to be stopped.
-			// 								e.stopPropagation();
-			// 								assert(
-			// 									node.component.__typename !== "%other" &&
-			// 										node.component.__typename !== "virtualGroup"
-			// 								);
-			// 								setAddComponentModalOpenForDeviceId(node.component.id);
-			// 							}}
-			// 						>
-			// 							<EuiIcon type="plusInCircle" />
-			// 						</div>
-			// 					</EuiToolTip>
-			// 				</EuiFlexItem>
-			// 			)}
-			//
-			// 			<EuiFlexItem grow={false}>
-			// 				<EuiToolTip content={`Remove usage from ${node.name} slot.`}>
-			// 					<div
-			// 						className="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--xSmall"
-			// 						onClick={(e) => {
-			// 							// This div acts as a button (minus icon) inside
-			// 							// another button (row of the tree component). To
-			// 							// avoid a click on the tree element the propagation
-			// 							// has to be stopped.
-			// 							e.stopPropagation();
-			// 							assert(
-			// 								node.component.__typename !== "%other" &&
-			// 									node.component.__typename !== "virtualGroup"
-			// 							);
-			// 							setRemoveComponentModalOpenForDeviceId(node.component.id);
-			// 						}}
-			// 					>
-			// 						{removeComponentsMutationInFlight ? (
-			// 							<EuiLoadingSpinner size="s" />
-			// 						) : (
-			// 							<EuiIcon type="minusInCircle" />
-			// 						)}
-			// 					</div>
-			// 				</EuiToolTip>
-			// 			</EuiFlexItem>
-			//
-			// 			<EuiFlexItem grow={false}>
-			// 				<EuiToolTip content={`Edit ${node.component.name} usage in ${node.name} slot.`}>
-			// 					<div
-			// 						className="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--xSmall"
-			// 						onClick={(e) => {
-			// 							// This div acts as a button (pencil icon) inside
-			// 							// another button (row of the tree component). To
-			// 							// avoid a click on the tree element the propagation
-			// 							// has to be stopped.
-			// 							assert(
-			// 								node.component.__typename !== "%other" &&
-			// 									node.component.__typename !== "virtualGroup"
-			// 							);
-			// 							assert(node.component.usagesAsProperty[0].device?.id);
-			// 							e.stopPropagation();
-			// 							setEditComponentModalOpen({
-			// 								deviceId: node.component.usagesAsProperty[0].device.id,
-			// 								propertyId: node.component.usagesAsProperty[0].id,
-			// 								begin: new Date(node.component.usagesAsProperty[0].timestamp),
-			// 								end: node.component.usagesAsProperty[0].timestampEnd
-			// 									? new Date(node.component.usagesAsProperty[0].timestampEnd)
-			// 									: undefined,
-			// 								slot: node.component.usagesAsProperty[0].name,
-			// 								component: node.component.id,
-			// 							});
-			// 						}}
-			// 					>
-			// 						{removeComponentsMutationInFlight ? (
-			// 							<EuiLoadingSpinner size="s" />
-			// 						) : (
-			// 							<EuiIcon type="pencil" />
-			// 						)}
-			// 					</div>
-			// 				</EuiToolTip>
-			// 			</EuiFlexItem>
-			//
-			// 			<EuiFlexItem grow={false}>
-			// 				<EuiToolTip content={`Swap ${node.component.name} in ${node.name} slot.`}>
-			// 					<div
-			// 						className="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--xSmall"
-			// 						onClick={(e) => {
-			// 							// This div acts as a button (inputOutput icon) inside
-			// 							// another button (row of the tree component). To
-			// 							// avoid a click on the tree element the propagation
-			// 							// has to be stopped.
-			// 							assert(
-			// 								node.component.__typename !== "%other" &&
-			// 									node.component.__typename !== "virtualGroup"
-			// 							);
-			// 							assert(node.component.usagesAsProperty[0].device?.id);
-			// 							e.stopPropagation();
-			// 							setSwapComponentModalOpen({
-			// 								deviceId: node.component.usagesAsProperty[0].device.id,
-			// 								propertyId: node.component.usagesAsProperty[0].id,
-			// 							});
-			// 						}}
-			// 					>
-			// 						{removeComponentsMutationInFlight ? (
-			// 							<EuiLoadingSpinner size="s" />
-			// 						) : (
-			// 							<EuiIcon type="inputOutput" />
-			// 						)}
-			// 					</div>
-			// 				</EuiToolTip>
-			// 			</EuiFlexItem>
-			// 		</>
-			// 	);
 
 			const treeEntryId =
 				node.component.__typename == "virtualGroup"

--- a/apps/desktop-app/src/components/device/DeviceOverview.tsx
+++ b/apps/desktop-app/src/components/device/DeviceOverview.tsx
@@ -47,6 +47,7 @@ import type { AdactaTimelineSample$data } from "@/relay/AdactaTimelineSample.gra
 import type { AdactaTimelineUsage$data } from "@/relay/AdactaTimelineUsage.graphql";
 import type { DeviceOverview$key } from "@/relay/DeviceOverview.graphql";
 import { TopLevelDevice } from "~/apps/desktop-app/src/components/device/TopLevelDevice";
+import { ResourceListTable } from "~/apps/desktop-app/src/components/resource/list/ResourceListTable";
 import { renderSpecification } from "~/apps/desktop-app/src/components/specifications/specialMeaningSpecificationsKeys";
 import { assertDefined } from "~/lib/assert/assertDefined";
 import { isNonNullish } from "~/lib/assert/isNonNullish";
@@ -132,6 +133,7 @@ const DeviceOverViewGraphQLFragment = graphql`
 			begin
 			end
 			...AdactaTimelineResource @relay(mask: false)
+			...ResourceListTableFragment
 		}
 		notes {
 			__id
@@ -445,6 +447,17 @@ export function DeviceOverview(props: IProps) {
 										id: "samples",
 										label: "Samples",
 										content: <EuiDescriptionList type="row" listItems={samples} />,
+									},
+							  ]
+							: []),
+						...(device.usageInResource.length > 0
+							? [
+									{
+										id: "Resources",
+										label: "Resources",
+										content: (
+											<ResourceListTable resources={device.usageInResource} connections={[]} />
+										),
 									},
 							  ]
 							: []),

--- a/apps/desktop-app/src/components/device/DeviceOverview.tsx
+++ b/apps/desktop-app/src/components/device/DeviceOverview.tsx
@@ -456,7 +456,10 @@ export function DeviceOverview(props: IProps) {
 										id: "Resources",
 										label: "Resources",
 										content: (
-											<ResourceListTable resources={device.usageInResource} connections={[]} />
+											<ResourceListTable
+												resources={device.usageInResource.filter(isNonNullish)}
+												connections={[]}
+											/>
 										),
 									},
 							  ]

--- a/apps/desktop-app/src/components/device/DeviceOverview.tsx
+++ b/apps/desktop-app/src/components/device/DeviceOverview.tsx
@@ -144,6 +144,13 @@ const DeviceOverViewGraphQLFragment = graphql`
 				}
 			}
 		}
+		projects {
+			edges {
+				node {
+					id
+				}
+			}
+		}
 		...ComponentEuiTree @arguments(time: $time)
 		...SetupDescriptionComponent @arguments(time: $time)
 		...DeviceEditFragment
@@ -492,7 +499,10 @@ export function DeviceOverview(props: IProps) {
 											<EuiFlexGroup justifyContent="center">
 												<EuiFlexItem grow={false}>
 													{}
-													<FileUpload deviceId={device.id as IDeviceId} />
+													<FileUpload
+														deviceId={device.id as IDeviceId}
+														defaultProjects={device.projects.edges.map((e) => e.node.id)}
+													/>
 												</EuiFlexItem>
 											</EuiFlexGroup>
 										),

--- a/apps/desktop-app/src/components/device/DeviceOverview.tsx
+++ b/apps/desktop-app/src/components/device/DeviceOverview.tsx
@@ -291,6 +291,10 @@ export function DeviceOverview(props: IProps) {
 				};
 			}) ?? [];
 
+	// For some devices it is preferred to show the specifications tab as default (i.e. for devices
+	// with no components)
+	const showSpecificationsAsDefaultTab = device.properties.length === 0 && specification.length > 0;
+
 	return (
 		<>
 			{deviceEditor && <DeviceEdit closeModal={() => setDeviceEditor(false)} device={device} />}
@@ -413,6 +417,7 @@ export function DeviceOverview(props: IProps) {
 									{
 										id: "specifications",
 										label: "Specifications",
+										isSelected: showSpecificationsAsDefaultTab,
 										content: (
 											<>
 												{!props.popoverMode && (

--- a/apps/desktop-app/src/components/device/DevicePageLoading.tsx
+++ b/apps/desktop-app/src/components/device/DevicePageLoading.tsx
@@ -52,6 +52,12 @@ export function DevicePageLoading() {
 						disabled: true,
 					},
 					{
+						id: "resources",
+						label: "Resources",
+						content: <></>,
+						disabled: true,
+					},
+					{
 						id: "activity",
 						label: "History",
 						content: <></>,

--- a/apps/desktop-app/src/components/device/SetupDescriptionComponent.tsx
+++ b/apps/desktop-app/src/components/device/SetupDescriptionComponent.tsx
@@ -46,6 +46,7 @@ import type { SetupDescriptionComponentDeleteMutation } from "@/relay/SetupDescr
 import type { SetupDescriptionComponentLinkImageMutation } from "@/relay/SetupDescriptionComponentLinkImageMutation.graphql";
 import type { SetupDescriptionComponentUpdateDatesMutation } from "@/relay/SetupDescriptionComponentUpdateDatesMutation.graphql";
 import type { ShowIfUserCanEdit$key } from "@/relay/ShowIfUserCanEdit.graphql";
+import { SampleLink } from "~/apps/desktop-app/src/components/sample/SampleLink";
 import { assertDefined } from "~/lib/assert/assertDefined";
 import {
 	createDate,
@@ -322,7 +323,7 @@ function SetupDescriptionComponentPure(props: IProps & { data: SetupDescriptionC
 		const unlabeledComponents: IAvailableLabel[] = [];
 		for (const node of tree) {
 			let newPropertyPath: string[];
-			if (node.component.__typename === "Device") {
+			if (node.component.__typename === "Device" || node.component.__typename === "Sample") {
 				newPropertyPath = splitPropertyNameIntoVirtualGroups([
 					...propertyPath,
 					node.component.usagesAsProperty[0].name,
@@ -332,13 +333,16 @@ function SetupDescriptionComponentPure(props: IProps & { data: SetupDescriptionC
 					annotations.push({
 						x: setupLabel.xPos,
 						y: setupLabel.yPos,
-						label: (
-							<DeviceLink
-								data={node.component.usagesAsProperty[0].value}
-								timestamp={timestamp}
-								textOverwrite={showSlotNames ? node.name : node.tag}
-							/>
-						),
+						label:
+							node.component.__typename === "Device" ? (
+								<DeviceLink
+									data={node.component.usagesAsProperty[0].value}
+									timestamp={timestamp}
+									textOverwrite={showSlotNames ? node.name : node.tag}
+								/>
+							) : (
+								<SampleLink sample={node.component.usagesAsProperty[0].value} />
+							),
 					});
 				} else {
 					// List all components that are not described in the setup description

--- a/apps/desktop-app/src/components/device/modals/AddComponentUsageModal.tsx
+++ b/apps/desktop-app/src/components/device/modals/AddComponentUsageModal.tsx
@@ -88,7 +88,7 @@ export function AddComponentUsageModal(props: IProps) {
 			onError: (e) => toaster.addToast("Add component failed", e.message, "danger"),
 			updater: (cache) => {
 				if (!props.viewTimestamp) {
-					// Invalidate cache if we are viewing a "live" viewtimedProperties
+					// Invalidate cache if we are viewing a "live" properties
 					cache.invalidateStore();
 				}
 			},

--- a/apps/desktop-app/src/components/device/modals/AddOrEditComponentUsageModal.tsx
+++ b/apps/desktop-app/src/components/device/modals/AddOrEditComponentUsageModal.tsx
@@ -200,7 +200,7 @@ export function AddOrEditComponentUsageModal(props: IProps) {
 						/>
 						<EuiSpacer size={"xs"} />
 						<EuiText size={"xs"} color={"subdued"}>
-							Select a slot from the the list. A new slot can be created by entering text.
+							Select a slot from the list. A new slot can be created by entering text.
 							<br />
 							To group multiple slots, use a slash (/) in the name (i.e. &quot;Gas Dosage/MFC
 							3&quot;)

--- a/apps/desktop-app/src/components/device/modals/AddOrEditComponentUsageModal.tsx
+++ b/apps/desktop-app/src/components/device/modals/AddOrEditComponentUsageModal.tsx
@@ -15,6 +15,7 @@ import {
 	EuiSpacer,
 	EuiSuperSelect,
 	EuiSwitch,
+	EuiText,
 } from "@elastic/eui";
 import type { Moment } from "moment";
 import moment from "moment";
@@ -189,17 +190,22 @@ export function AddOrEditComponentUsageModal(props: IProps) {
 				</EuiModalHeaderTitle>
 			</EuiModalHeader>
 			<EuiModalBody>
-				<EuiFormRow
-					fullWidth
-					label="Slot"
-					helpText={"Select a slot from the the list. A new slot can be created by entering text."}
-				>
-					<SlotSelection
-						propertyDefinitions={data.definition.propertyDefinitions as IPropertyDefinition[]}
-						value={propertyName}
-						onChange={setPropertyName}
-						editMode={props.existingProperty !== undefined}
-					/>
+				<EuiFormRow fullWidth label="Slot">
+					<>
+						<SlotSelection
+							propertyDefinitions={data.definition.propertyDefinitions as IPropertyDefinition[]}
+							value={propertyName}
+							onChange={setPropertyName}
+							editMode={props.existingProperty !== undefined}
+						/>
+						<EuiSpacer size={"xs"} />
+						<EuiText size={"xs"} color={"subdued"}>
+							Select a slot from the the list. A new slot can be created by entering text.
+							<br />
+							To group multiple slots, use a slash (/) in the name (i.e. &quot;Gas Dosage/MFC
+							3&quot;)
+						</EuiText>
+					</>
 				</EuiFormRow>
 				{invalidDateRange !== null && (
 					<>

--- a/apps/desktop-app/src/components/device/modals/AddOrEditComponentUsageModal.tsx
+++ b/apps/desktop-app/src/components/device/modals/AddOrEditComponentUsageModal.tsx
@@ -284,12 +284,12 @@ export function AddOrEditComponentUsageModal(props: IProps) {
 						</Suspense>
 						{(selectedSlotType === undefined || selectedSlotType === "Device") && (
 							<EuiFlexItem grow={false}>
-								<EuiButton onClick={() => setShowCreateDeviceModal(true)}>Add Device</EuiButton>
+								<EuiButton onClick={() => setShowCreateDeviceModal(true)}>Create Device</EuiButton>
 							</EuiFlexItem>
 						)}
 						{(selectedSlotType === undefined || selectedSlotType === "Sample") && (
 							<EuiFlexItem grow={false}>
-								<EuiButton onClick={() => setShowCreateSampleModal(true)}>Add Sample</EuiButton>
+								<EuiButton onClick={() => setShowCreateSampleModal(true)}>Create Sample</EuiButton>
 							</EuiFlexItem>
 						)}
 					</EuiFlexGroup>

--- a/apps/desktop-app/src/components/device/modals/AddOrEditComponentUsageModal.tsx
+++ b/apps/desktop-app/src/components/device/modals/AddOrEditComponentUsageModal.tsx
@@ -29,6 +29,7 @@ import { SlotSelection } from "../SlotSelection";
 
 import type { AddOrEditComponentUsageModalFragment$key } from "@/relay/AddOrEditComponentUsageModalFragment.graphql";
 import { DeviceAdd } from "~/apps/desktop-app/src/components/device/DeviceAdd";
+import { SampleAdd } from "~/apps/desktop-app/src/components/sample/SampleAdd";
 import { assertDefined } from "~/lib/assert/assertDefined";
 import type { IPropertyDefinition } from "~/lib/interface/IPropertyDefinition";
 
@@ -89,7 +90,10 @@ export function AddOrEditComponentUsageModal(props: IProps) {
 	// `isOpenEnd` from on to off
 	const [end, setEnd] = useState(initialEnd ?? new Date(Date.now() + 24 * 60 * 60 * 1000));
 	const [isOpenEnd, setIsOpenEnd] = useState(initialEnd == undefined);
+
+	// Modals for adding devices and samples
 	const [showCreateDeviceModal, setShowCreateDeviceModal] = useState(false);
+	const [showCreateSampleModal, setShowCreateSampleModal] = useState(false);
 
 	const data = initialData;
 
@@ -168,6 +172,12 @@ export function AddOrEditComponentUsageModal(props: IProps) {
 				closeModal={() => setShowCreateDeviceModal(false)}
 				connections={{ connectionIdFlat: [], connectionIdHierarchical: [] }}
 			/>
+		);
+	}
+
+	if (showCreateSampleModal) {
+		return (
+			<SampleAdd closeModal={() => setShowCreateSampleModal(false)} connectionId={undefined} />
 		);
 	}
 
@@ -266,9 +276,16 @@ export function AddOrEditComponentUsageModal(props: IProps) {
 								/>
 							</EuiFlexItem>
 						</Suspense>
-						<EuiFlexItem grow={false}>
-							<EuiButton onClick={() => setShowCreateDeviceModal(true)}>Add Device</EuiButton>
-						</EuiFlexItem>
+						{(selectedSlotType === undefined || selectedSlotType === "Device") && (
+							<EuiFlexItem grow={false}>
+								<EuiButton onClick={() => setShowCreateDeviceModal(true)}>Add Device</EuiButton>
+							</EuiFlexItem>
+						)}
+						{(selectedSlotType === undefined || selectedSlotType === "Sample") && (
+							<EuiFlexItem grow={false}>
+								<EuiButton onClick={() => setShowCreateSampleModal(true)}>Add Sample</EuiButton>
+							</EuiFlexItem>
+						)}
 					</EuiFlexGroup>
 				</EuiFormRow>
 			</EuiModalBody>

--- a/apps/desktop-app/src/components/importWizzard/date/formats/DateFormatStringInput.tsx
+++ b/apps/desktop-app/src/components/importWizzard/date/formats/DateFormatStringInput.tsx
@@ -1,4 +1,4 @@
-import { EuiFieldText, EuiInputPopover } from "@elastic/eui";
+import { EuiCallOut, EuiFieldText, EuiInputPopover, EuiText } from "@elastic/eui";
 import React, { useState } from "react";
 
 type TInputMode = "date" | "time" | "combined";
@@ -40,8 +40,8 @@ function TokenExplanation(props: { inputMode: TInputMode }) {
 	const dateTokens = [
 		{ token: "YYYY", example: "2025", description: "4 digit year" },
 		{ token: "YY", example: "25", description: "2 digit year" },
-		{ token: "M MM", example: "1..12", description: "Month number" },
-		{ token: "D DD", example: "1..31", description: "Day of month" },
+		{ token: "MM", example: "1..12", description: "Month number" },
+		{ token: "DD", example: "1..31", description: "Day of month" },
 		{ token: "Do", example: "1st..31st", description: "Day of month with ordinal" },
 	];
 
@@ -55,12 +55,12 @@ function TokenExplanation(props: { inputMode: TInputMode }) {
 	// Z ZZ	+12:00	Offset from UTC as +-HH:mm, +-HHmm, or Z
 	const timeTokens = [
 		{
-			token: "H HH",
+			token: "HH",
 			example: "0..23",
 			description: "Hours (24 hour time)",
 		},
 		{
-			token: "h hh",
+			token: "hh",
 			example: "1..12",
 			description: "Hours (12 hour time used with a A.)",
 		},
@@ -70,12 +70,12 @@ function TokenExplanation(props: { inputMode: TInputMode }) {
 			description: "Post or ante meridiem (Note the one character a p are also considered valid)",
 		},
 		{
-			token: "m mm",
+			token: "mm",
 			example: "0..59",
 			description: "Minutes",
 		},
 		{
-			token: "s ss",
+			token: "ss",
 			example: "0..59",
 			description: "Seconds",
 		},
@@ -145,6 +145,14 @@ function TokenExplanation(props: { inputMode: TInputMode }) {
 						))}
 				</tbody>
 			</table>
+			{props.inputMode !== "date" && (
+				<EuiCallOut color={"primary"} title={"Example"}>
+					<EuiText size={"xs"}>
+						The format HH:mm:ss.SSS applied to the value 01:30:05.123 represents 1 hour, 30 minutes,
+						5 seconds, and 123 milliseconds
+					</EuiText>
+				</EuiCallOut>
+			)}
 		</div>
 	);
 }

--- a/apps/desktop-app/src/components/importWizzard/date/formats/DateFormatStringInput.tsx
+++ b/apps/desktop-app/src/components/importWizzard/date/formats/DateFormatStringInput.tsx
@@ -1,0 +1,150 @@
+import { EuiFieldText, EuiInputPopover } from "@elastic/eui";
+import React, { useState } from "react";
+
+type TInputMode = "date" | "time" | "combined";
+
+export function DateFormatStringInput(props: {
+	value: string;
+	onChange: (e: string) => void;
+	inputMode: TInputMode;
+}) {
+	const [isPopoverOpen, setPopoverOpen] = useState(false);
+	return (
+		<EuiInputPopover
+			input={
+				<EuiFieldText
+					value={props.value}
+					onChange={(e) => props.onChange(e.target.value)}
+					onFocus={() => setPopoverOpen(true)}
+					onBlur={() => setPopoverOpen(false)}
+				/>
+			}
+			isOpen={isPopoverOpen}
+			closePopover={() => setPopoverOpen(false)}
+		>
+			<TokenExplanation inputMode={props.inputMode} />
+		</EuiInputPopover>
+	);
+}
+
+function TokenExplanation(props: { inputMode: TInputMode }) {
+	// YYYY	2014	4 or 2 digit year. Note: Only 4 digit can be parsed on strict mode
+	// YY	14	2 digit year
+	// Y	-25	Year with any number of digits and sign
+	// Q	1..4	Quarter of year. Sets month to first month in quarter.
+	// 	M MM	1..12	Month number
+	// MMM MMMM	Jan..December	Month name in locale set by moment.locale()
+	// D DD	1..31	Day of month
+	// Do	1st..31st	Day of month with ordinal
+
+	const dateTokens = [
+		{ token: "YYYY", example: "2025", description: "4 digit year" },
+		{ token: "YY", example: "25", description: "2 digit year" },
+		{ token: "M MM", example: "1..12", description: "Month number" },
+		{ token: "D DD", example: "1..31", description: "Day of month" },
+		{ token: "Do", example: "1st..31st", description: "Day of month with ordinal" },
+	];
+
+	// H HH	0..23	Hours (24 hour time)
+	// h hh	1..12	Hours (12 hour time used with a A.)
+	// k kk	1..24	Hours (24 hour time from 1 to 24)
+	// a A	am pm	Post or ante meridiem (Note the one character a p are also considered valid)
+	// m mm	0..59	Minutes
+	// s ss	0..59	Seconds
+	// S SS SSS ... SSSSSSSSS	0..999999999	Fractional seconds
+	// Z ZZ	+12:00	Offset from UTC as +-HH:mm, +-HHmm, or Z
+	const timeTokens = [
+		{
+			token: "H HH",
+			example: "0..23",
+			description: "Hours (24 hour time)",
+		},
+		{
+			token: "h hh",
+			example: "1..12",
+			description: "Hours (12 hour time used with a A.)",
+		},
+		{
+			token: "a A",
+			example: "am pm",
+			description: "Post or ante meridiem (Note the one character a p are also considered valid)",
+		},
+		{
+			token: "m mm",
+			example: "0..59",
+			description: "Minutes",
+		},
+		{
+			token: "s ss",
+			example: "0..59",
+			description: "Seconds",
+		},
+		{
+			token: "S SSS",
+			example: "0...999",
+			description: "Fractional seconds",
+		},
+	];
+
+	return (
+		<div className="relative overflow-x-auto sm:rounded-lg">
+			<table className="w-full text-sm text-left rtl:text-right text-gray-500 ">
+				<thead className="text-xs text-gray-700 uppercase bg-gray-50 ">
+					<tr>
+						<th scope="col" className="px-6 py-3">
+							Token
+						</th>
+						<th scope="col" className="px-6 py-3">
+							Example
+						</th>
+						<th scope="col" className="px-6 py-3">
+							Description
+						</th>
+					</tr>
+				</thead>
+				<tbody>
+					{props.inputMode === "combined" && (
+						<tr className="odd:bg-white  even:bg-gray-50  border-b  border-gray-200">
+							<td colSpan={3} className={"px-4 py-4 font-bold text-gray-900 whitespace-nowrap"}>
+								Date Tokens
+							</td>
+						</tr>
+					)}
+					{props.inputMode !== "time" &&
+						dateTokens.map((token) => (
+							<tr
+								key={token.token}
+								className="odd:bg-white  even:bg-gray-50  border-b  border-gray-200"
+							>
+								<th scope="row" className="px-6 py-4 font-medium text-gray-900 whitespace-nowrap ">
+									{token.token}
+								</th>
+								<td className="px-6 py-4">{token.example}</td>
+								<td className="px-6 py-4">{token.description}</td>
+							</tr>
+						))}
+					{props.inputMode === "combined" && (
+						<tr className="odd:bg-white  even:bg-gray-50  border-b  border-gray-200">
+							<td colSpan={3} className={"px-4 py-4 font-bold text-gray-900 whitespace-nowrap"}>
+								Time Tokens
+							</td>
+						</tr>
+					)}
+					{props.inputMode !== "date" &&
+						timeTokens.map((token) => (
+							<tr
+								key={token.token}
+								className="odd:bg-white  even:bg-gray-50  border-b  border-gray-200"
+							>
+								<th scope="row" className="px-6 py-4 font-medium text-gray-900 whitespace-nowrap ">
+									{token.token}
+								</th>
+								<td className="px-6 py-4">{token.example}</td>
+								<td className="px-6 py-4">{token.description}</td>
+							</tr>
+						))}
+				</tbody>
+			</table>
+		</div>
+	);
+}

--- a/apps/desktop-app/src/components/importWizzard/date/formats/DateTimeCombined.tsx
+++ b/apps/desktop-app/src/components/importWizzard/date/formats/DateTimeCombined.tsx
@@ -1,11 +1,12 @@
 import assert from "assert";
 
-import { EuiFieldText, EuiFlexItem, EuiFormRow } from "@elastic/eui";
+import { EuiFlexItem, EuiFormRow } from "@elastic/eui";
 import React from "react";
 
 import { renderPreview } from "./utils/renderPreview";
 import { useDebounceFormUpdate } from "../../../utils/useDebouncedFormUpdate";
 
+import { DateFormatStringInput } from "~/apps/desktop-app/src/components/importWizzard/date/formats/DateFormatStringInput";
 import type { IColumnTimeConfig } from "~/lib/interface/IImportWizardPreset";
 
 interface IProps {
@@ -31,7 +32,7 @@ export function DateTimeCombined({ dataRow, headerRow, config, setConfig }: IPro
 	return (
 		<EuiFlexItem grow={true}>
 			<EuiFormRow display="rowCompressed" label="Format">
-				<EuiFieldText value={format} onChange={(e) => setFormat(e.target.value)} />
+				<DateFormatStringInput value={format} onChange={setFormat} inputMode={"combined"} />
 			</EuiFormRow>
 			<EuiFormRow label="Preview">
 				<>{renderPreview(dataRow, headerRow, config, {})}</>

--- a/apps/desktop-app/src/components/importWizzard/date/formats/DateTimeSplit.tsx
+++ b/apps/desktop-app/src/components/importWizzard/date/formats/DateTimeSplit.tsx
@@ -1,8 +1,9 @@
 import assert from "assert";
 
-import { EuiFieldText, EuiFlexItem, EuiFormRow } from "@elastic/eui";
+import { EuiFlexItem, EuiFormRow } from "@elastic/eui";
 import React from "react";
 
+import { DateFormatStringInput } from "./DateFormatStringInput";
 import { renderPreview } from "./utils/renderPreview";
 import { useDebounceFormUpdate } from "../../../utils/useDebouncedFormUpdate";
 
@@ -63,9 +64,10 @@ export function DateTimeSplit({ dataRow, headerRow, config, configs, setConfig }
 	return (
 		<>
 			<EuiFlexItem grow={false}>
-				<EuiFormRow display="rowCompressed" label="Format">
-					<EuiFieldText value={format} onChange={(e) => setDateFormat(e.target.value)} />
+				<EuiFormRow display={"rowCompressed"} label="Format">
+					<DateFormatStringInput value={format} onChange={setDateFormat} inputMode={config.type} />
 				</EuiFormRow>
+
 				<EuiFormRow label="Preview">
 					<>{renderPreview(dataRow, headerRow, config, { targetFormat })}</>
 				</EuiFormRow>

--- a/apps/desktop-app/src/components/layout/TabbedPageLayout.tsx
+++ b/apps/desktop-app/src/components/layout/TabbedPageLayout.tsx
@@ -13,7 +13,7 @@ export function TabbedPageLayout(props: {
 		tabs: {
 			label: ReactNode;
 			id: string;
-			isSelected?: true;
+			isSelected?: boolean;
 			content: JSX.Element | null;
 			disabled?: true;
 		}[];

--- a/apps/desktop-app/src/components/resource/ResourceListPage.tsx
+++ b/apps/desktop-app/src/components/resource/ResourceListPage.tsx
@@ -14,7 +14,10 @@ import {
 	ResourceList,
 	ResourceListLoading,
 } from "~/apps/desktop-app/src/components/resource/ResourceList";
-import { SearchBar } from "~/apps/desktop-app/src/components/search/list/SearchBar";
+import {
+	getStoredSelectedSearchItems,
+	SearchBar,
+} from "~/apps/desktop-app/src/components/search/list/SearchBar";
 import { EDocId } from "~/apps/desktop-app/src/interfaces/EDocId";
 import { useService } from "~/apps/desktop-app/src/services/ServiceProvider";
 import { DocFlyoutService } from "~/apps/desktop-app/src/services/toaster/FlyoutService";
@@ -27,7 +30,9 @@ export function ResourceListPage(props: { queryRef: PreloadedQuery<ResourceListQ
 		useState<RefetchFnDynamic<ResourceListFragment, ResourceList$key>>();
 	const [resourceListVariables, setResourceListVariables] = useState<
 		Partial<ResourceListFragment$variables>
-	>({});
+	>({
+		filter: getStoredSelectedSearchItems("resourcesList"),
+	});
 
 	return (
 		<AdactaPageTemplate>

--- a/apps/desktop-app/src/components/resource/list/ResourceListTable.tsx
+++ b/apps/desktop-app/src/components/resource/list/ResourceListTable.tsx
@@ -48,8 +48,8 @@ export function ResourceListTable(
 
 const columns = [
 	"Name",
-	"Time of recording",
 	"Projects",
+	"Time of recording",
 	"Devices",
 	"Preview",
 	"Creator",

--- a/apps/desktop-app/src/components/resource/list/entry/RawEntry.tsx
+++ b/apps/desktop-app/src/components/resource/list/entry/RawEntry.tsx
@@ -11,6 +11,7 @@ import { ResourceLink } from "../../ResourceLink";
 import { columnCount } from "../ResourceListTable";
 
 import type { RawEntryFragment$key } from "@/relay/RawEntryFragment.graphql";
+import { ProjectListCollapsible } from "~/apps/desktop-app/src/components/project/ProjectListCollapsible";
 import { UserLink } from "~/apps/desktop-app/src/components/user/UserLink";
 import { assertDefined } from "~/lib/assert/assertDefined";
 
@@ -36,6 +37,7 @@ export function RawEntry(
 						...UserLink
 					}
 				}
+				...ProjectListCollapsible
 			}
 		`,
 		props.resource
@@ -59,7 +61,10 @@ export function RawEntry(
 					<ResourceLink resource={data} />
 				</PaddingHelper>
 			</EuiTableRowCell>
-			<EuiTableRowCell colSpan={columnCount - 3} align="center" color={"subdued"}>
+			<EuiTableRowCell>
+				<ProjectListCollapsible data={data} />
+			</EuiTableRowCell>
+			<EuiTableRowCell colSpan={columnCount - 4} align="center" color={"subdued"}>
 				<EuiText color={"subdued"} size={"xs"}>
 					<EuiLink color={"subdued"} onClick={handleImport}>
 						Import

--- a/apps/desktop-app/src/components/resource/list/entry/RawTabularMergedEntry.tsx
+++ b/apps/desktop-app/src/components/resource/list/entry/RawTabularMergedEntry.tsx
@@ -89,11 +89,11 @@ export function RawTabularMergedEntry(
 					</PaddingHelper>
 				</EuiTableRowCell>
 				<EuiTableRowCell>
-					<DateTime date={createMaybeDate(data.begin)} /> -{" "}
-					<DateTime date={createMaybeDate(data.end)} />
+					<ProjectListCollapsible data={data} />
 				</EuiTableRowCell>
 				<EuiTableRowCell>
-					<ProjectListCollapsible data={data} />
+					<DateTime date={createMaybeDate(data.begin)} /> -{" "}
+					<DateTime date={createMaybeDate(data.end)} />
 				</EuiTableRowCell>
 				<EuiTableRowCell>
 					<ResourceDevices devices={data.devices.filter(isNonNullish)} />

--- a/apps/desktop-app/src/components/sample/SampleAdd.tsx
+++ b/apps/desktop-app/src/components/sample/SampleAdd.tsx
@@ -26,7 +26,7 @@ import type {
 
 interface IProps {
 	closeModal: () => void;
-	connectionId: string;
+	connectionId?: string;
 }
 
 const SampleAddAppendGraphQLMutation: GraphQLTaggedNode = graphql`
@@ -57,7 +57,11 @@ export function SampleAdd(props: IProps) {
 
 	function addSample(input: SampleAddMutation$variables["input"]) {
 		commitAddSample({
-			variables: { input, connections: [props.connectionId], ...repositoryIdVariable },
+			variables: {
+				input,
+				connections: props.connectionId ? [props.connectionId] : [],
+				...repositoryIdVariable,
+			},
 			onError: (e) => toaster.addToast("Add sample failed", e.message, "danger"),
 			onCompleted: () => props.closeModal(),
 		});

--- a/apps/desktop-app/src/components/sample/SampleListPage.tsx
+++ b/apps/desktop-app/src/components/sample/SampleListPage.tsx
@@ -19,7 +19,10 @@ import type { SampleListQuery } from "@/relay/SampleListQuery.graphql";
 import { AdactaPageTemplate } from "~/apps/desktop-app/src/components/layout/AdactaPageTemplate";
 import { ManageNameCompositionButton } from "~/apps/desktop-app/src/components/nameComposition/ManageNameCompositionButton";
 import { SampleList, SampleListLoading } from "~/apps/desktop-app/src/components/sample/SampleList";
-import { SearchBar } from "~/apps/desktop-app/src/components/search/list/SearchBar";
+import {
+	getStoredSelectedSearchItems,
+	SearchBar,
+} from "~/apps/desktop-app/src/components/search/list/SearchBar";
 import { EDocId } from "~/apps/desktop-app/src/interfaces/EDocId";
 import { useService } from "~/apps/desktop-app/src/services/ServiceProvider";
 import { DocFlyoutService } from "~/apps/desktop-app/src/services/toaster/FlyoutService";
@@ -33,7 +36,7 @@ export function SampleListPage(props: { queryRef: PreloadedQuery<SampleListQuery
 	const [refetch, setRefetch] = useState<RefetchFnDynamic<SampleListFragment, SampleList$key>>();
 	const [sampleListVariables, setSampleListVariables] = useState<
 		Partial<SampleListFragment$variables>
-	>({});
+	>({ filter: getStoredSelectedSearchItems("sampleList") });
 
 	return (
 		<AdactaPageTemplate>

--- a/apps/desktop-app/src/components/search/list/SearchBar.tsx
+++ b/apps/desktop-app/src/components/search/list/SearchBar.tsx
@@ -25,6 +25,7 @@ import { SearchFilter } from "~/apps/desktop-app/src/components/search/list/Sear
 import { useSearchBarContext } from "~/apps/desktop-app/src/components/search/list/useSearchBarContext";
 import type { IStoredFilters } from "~/apps/desktop-app/src/interfaces/IStoredFilters";
 import type { InputMaybe, Scalars } from "~/apps/repo-server/src/graphql/generated/resolvers";
+import { CURRENT_USER_ID_PLACEHOLDER } from "~/lib/CURRENT_USER_ID_PLACEHOLDER";
 
 const SearchBarGraphQLQuery = graphql`
 	query SearchBarQuery {
@@ -458,5 +459,7 @@ export function getStoredSelectedSearchItems(
 			return undefined;
 		}
 		return undefined;
+	} else {
+		return { userIds: [CURRENT_USER_ID_PLACEHOLDER], projectIds: [], searchValue: "" };
 	}
 }

--- a/apps/desktop-app/src/routes/repositories.$repositoryId.resources._index.tsx
+++ b/apps/desktop-app/src/routes/repositories.$repositoryId.resources._index.tsx
@@ -8,7 +8,6 @@ import type { ResourceListQuery } from "@/relay/ResourceListQuery.graphql";
 import type { GetDataArgs, Props } from "@/routes/repositories.$repositoryId.resources._index";
 import { ResourceListPage } from "~/apps/desktop-app/src/components/resource/ResourceListPage";
 import { getStoredSelectedSearchItems } from "~/apps/desktop-app/src/components/search/list/SearchBar";
-import { CURRENT_USER_ID_PLACEHOLDER } from "~/lib/CURRENT_USER_ID_PLACEHOLDER";
 
 function getData({ match, relayEnvironment }: GetDataArgs) {
 	const storedFilters = getStoredSelectedSearchItems("resourcesList");
@@ -18,11 +17,7 @@ function getData({ match, relayEnvironment }: GetDataArgs) {
 		ResourceListGraphQLQuery,
 		{
 			repositoryId: match.params.repositoryId,
-			filter: {
-				...storedFilters,
-				userIds:
-					storedFilters === undefined ? [CURRENT_USER_ID_PLACEHOLDER] : storedFilters.userIds,
-			},
+			filter: storedFilters,
 		},
 		{ fetchPolicy: "store-and-network" }
 	);

--- a/apps/desktop-app/src/routes/repositories.$repositoryId.samples._index.tsx
+++ b/apps/desktop-app/src/routes/repositories.$repositoryId.samples._index.tsx
@@ -8,7 +8,6 @@ import type { SampleListQuery } from "@/relay/SampleListQuery.graphql";
 import type { GetDataArgs, Props } from "@/routes/repositories.$repositoryId.samples._index";
 import { SampleListPage } from "~/apps/desktop-app/src/components/sample/SampleListPage";
 import { getStoredSelectedSearchItems } from "~/apps/desktop-app/src/components/search/list/SearchBar";
-import { CURRENT_USER_ID_PLACEHOLDER } from "~/lib/CURRENT_USER_ID_PLACEHOLDER";
 
 function getData({ match, relayEnvironment }: GetDataArgs) {
 	const storedFilters = getStoredSelectedSearchItems("sampleList");
@@ -17,11 +16,7 @@ function getData({ match, relayEnvironment }: GetDataArgs) {
 		SampleListGraphQLQuery,
 		{
 			repositoryId: match.params.repositoryId,
-			filter: {
-				...storedFilters,
-				userIds:
-					storedFilters === undefined ? [CURRENT_USER_ID_PLACEHOLDER] : storedFilters.userIds,
-			},
+			filter: storedFilters,
 		},
 		{ fetchPolicy: "store-and-network" }
 	);

--- a/apps/desktop-app/src/utils/__tests__/createComponentNodeTree.spec.ts
+++ b/apps/desktop-app/src/utils/__tests__/createComponentNodeTree.spec.ts
@@ -8,9 +8,15 @@ import { createIDatetime } from "~/lib/createDate";
 
 test("createComponentNodeTree", () => {
 	// The value property is not used by the function under test, so we can omit it.
-	const fakeRef = {
+	const fakeRefDevice = {
 		value: null as unknown as {
 			readonly " $fragmentSpreads": FragmentRefs<"DeviceLink">;
+		},
+	};
+
+	const fakeRefSample = {
+		value: null as unknown as {
+			readonly " $fragmentSpreads": FragmentRefs<"SampleLink">;
 		},
 	};
 
@@ -27,7 +33,7 @@ test("createComponentNodeTree", () => {
 						timestampEnd: createIDatetime(new Date(0)),
 						id: "fakePropertyId",
 						device: { id: "fakeDeviceId" },
-						...fakeRef,
+						...fakeRefSample,
 					},
 				],
 			},
@@ -46,7 +52,7 @@ test("createComponentNodeTree", () => {
 						timestampEnd: createIDatetime(new Date(0)),
 						id: "fakePropertyId",
 						device: { id: "fakeDeviceId" },
-						...fakeRef,
+						...fakeRefDevice,
 					},
 				],
 				definition: {
@@ -68,7 +74,7 @@ test("createComponentNodeTree", () => {
 						timestampEnd: createIDatetime(new Date(0)),
 						id: "fakePropertyId",
 						device: { id: "fakeDeviceId" },
-						...fakeRef,
+						...fakeRefDevice,
 					},
 				],
 				definition: {
@@ -90,7 +96,7 @@ test("createComponentNodeTree", () => {
 						timestampEnd: createIDatetime(new Date(0)),
 						id: "fakePropertyId",
 						device: { id: "fakeDeviceId" },
-						...fakeRef,
+						...fakeRefDevice,
 					},
 				],
 				definition: {

--- a/apps/repo-server/graphql/types.graphql
+++ b/apps/repo-server/graphql/types.graphql
@@ -567,6 +567,8 @@ input ImportRawResourceInput {
 	name: String!
 	uploadId: ID!
 	uploadDevice: ID!
+
+	projects: [ID!]
 }
 
 input OriginRepoMetadataInput {

--- a/apps/repo-server/src/graphql/generated/requests.ts
+++ b/apps/repo-server/src/graphql/generated/requests.ts
@@ -1482,6 +1482,7 @@ export type IImportRawResourceInput = {
 	name: Scalars["String"];
 	uploadId: Scalars["ID"];
 	uploadDevice: Scalars["ID"];
+	projects?: InputMaybe<Array<Scalars["ID"]>>;
 };
 
 export type IImportImageResourceInput = {

--- a/apps/repo-server/src/graphql/generated/resolvers.ts
+++ b/apps/repo-server/src/graphql/generated/resolvers.ts
@@ -1484,6 +1484,7 @@ export type IImportRawResourceInput = {
 	name: Scalars["String"];
 	uploadId: Scalars["ID"];
 	uploadDevice: Scalars["ID"];
+	projects?: InputMaybe<Array<Scalars["ID"]>>;
 };
 
 export type IImportImageResourceInput = {

--- a/apps/repo-server/src/graphql/generated/schema.graphql
+++ b/apps/repo-server/src/graphql/generated/schema.graphql
@@ -1014,6 +1014,7 @@ input ImportRawResourceInput {
 	name: String!
 	uploadId: ID!
 	uploadDevice: ID!
+	projects: [ID!]
 }
 
 input ImportImageResourceInput {

--- a/apps/repo-server/src/graphql/resolvers/Import.ts
+++ b/apps/repo-server/src/graphql/resolvers/Import.ts
@@ -2,7 +2,6 @@ import assert from "node:assert";
 
 import { and, arrayContains, asc, isNotNull } from "drizzle-orm";
 import probe from "probe-image-size";
-import { a } from "vite-node/index-O2IrwHKf";
 
 import { createResourceFromUpload } from "./utils/createResourceFromUpload";
 import { paginateDocuments } from "./utils/paginateDocuments";

--- a/apps/repo-server/src/graphql/resolvers/Import.ts
+++ b/apps/repo-server/src/graphql/resolvers/Import.ts
@@ -2,6 +2,7 @@ import assert from "node:assert";
 
 import { and, arrayContains, asc, isNotNull } from "drizzle-orm";
 import probe from "probe-image-size";
+import { a } from "vite-node/index-O2IrwHKf";
 
 import { createResourceFromUpload } from "./utils/createResourceFromUpload";
 import { paginateDocuments } from "./utils/paginateDocuments";
@@ -23,8 +24,12 @@ export const ImportMutations: IResolvers["RepositoryMutation"] = {
 		return { id: uploadId, url };
 	},
 
-	async importRawResource(_, { input }, { userId, services: { rm } }) {
-		return createResourceFromUpload(
+	async importRawResource(
+		_,
+		{ input },
+		{ userId, services: { rm, el }, schema: { ProjectToResource } }
+	) {
+		const resourceId = await createResourceFromUpload(
 			input.uploadId,
 			input.name,
 			{
@@ -35,6 +40,15 @@ export const ImportMutations: IResolvers["RepositoryMutation"] = {
 			rm,
 			userId
 		);
+
+		if (input.projects) {
+			for (const projectId of input.projects) {
+				assert(isEntityId(projectId, "Project"));
+				await el.insert(ProjectToResource, { projectId, resourceId: resourceId });
+			}
+		}
+
+		return resourceId;
 	},
 
 	async importImageResource(_, { input }, { userId, services: { rm, sto } }) {


### PR DESCRIPTION
- Fix for VirtualGroups that didn't always render correctly when a VirtualGroup had only other VirtualGroups as a children
- Fix for changelog which crashed when a sample was part of the events
- Fix for filters in the Resource/Sample list: Saved filters are now correctly taken into account when the user changes the filters.

- Update component tree: Replace "Edit Mode" with a context menu next to each component
- Allow the creation of samples when adding a component or editing a component usage
- Device Overview
     - If a device has no components, the Specifications tab is now displayed by default
     - Show resources related to the setup
- Setup Description: Allow placement of tags for samples
- Resource Upload: Allow assignment of projects when uploading new files
- ImportWizard: Added a small tooltip explaining possible tokens for parsing date/time strings.