### PR TITLE
Don't rename empty columns for internal usage

### DIFF
--- a/apps/repo-server/src/csvImportWizard/__tests__/makeHeadersUnique.spec.ts
+++ b/apps/repo-server/src/csvImportWizard/__tests__/makeHeadersUnique.spec.ts
@@ -7,4 +7,9 @@ describe("makeHeadersUnique", () => {
 		const headers = ["a", "b", "a", "c", "b"];
 		expect(makeHeadersUnique(headers)).toEqual(["a (1)", "b (1)", "a (2)", "c", "b (2)"]);
 	});
+
+	test("keeps empty headers empty", () => {
+		const headers = ["a", "", "a", "", "b"];
+		expect(makeHeadersUnique(headers)).toEqual(["a (1)", "", "a (2)", "", "b"]);
+	});
 });

--- a/apps/repo-server/src/csvImportWizard/makeHeadersUnique.ts
+++ b/apps/repo-server/src/csvImportWizard/makeHeadersUnique.ts
@@ -24,6 +24,11 @@ export function makeHeadersUnique(headers: readonly string[]): string[] {
 
 	// Modify the newHeaders array to add the suffix to any repeated header names
 	for (const [columnName, appearances] of headerToIndexMap) {
+		if (columnName.trim() === "") {
+			// Don't modify empty headers. Otherwise (repeated) empty headers would be renamed to
+			// " (1)", " (2)", etc.
+			continue;
+		}
 		if (appearances.length > 1) {
 			for (let i = 0; i < appearances.length; i++) {
 				const appearance = appearances[i];


### PR DESCRIPTION
The logic for generating unique (internal) column names renamed empty column headers (if they occurred multiple times). This disrupted the logic for detecting empty trailing columns and caused an unnecessary error message.