### PR TITLE
Handle errors for downsampling tasks and update related logic + `ImportWizard` error on empty resource

### DIFF
--- a/apps/desktop-app/src/components/chart/Sparkline.tsx
+++ b/apps/desktop-app/src/components/chart/Sparkline.tsx
@@ -16,15 +16,18 @@ import { assertDefined } from "~/lib/assert/assertDefined";
 const SparklineGraphQLFragment = graphql`
 	fragment Sparkline on ResourceTabularData {
 		downSampled(dataPoints: 18, singleColumn: true) {
-			x {
-				label
-				unit
-				values
-			}
-			y {
-				label
-				unit
-				values
+			__typename
+			... on Data {
+				x {
+					label
+					unit
+					values
+				}
+				y {
+					label
+					unit
+					values
+				}
 			}
 		}
 	}
@@ -33,7 +36,7 @@ const SparklineGraphQLFragment = graphql`
 export function Sparklines(props: { resource: Sparkline$key }) {
 	const f = useFragment(SparklineGraphQLFragment, props.resource);
 
-	if (f === null) return <div>No preview available</div>;
+	if (f === null || f.downSampled?.__typename !== "Data") return <div>No preview available</div>;
 
 	const { downSampled: data } = f;
 

--- a/apps/repo-server/graphql/types.graphql
+++ b/apps/repo-server/graphql/types.graphql
@@ -1078,8 +1078,10 @@ type ResourceTabularData implements Node & Resource & ResourceTimed & HasProject
 	If singleColumn is set to true only one y axis will be select and down sampled. Currently, an attempt is made to
 	select a specific column position in which the reactor temperature is often (but not always) located.
 	"""
-	downSampled(dataPoints: Int!, singleColumn: Boolean): Data
+	downSampled(dataPoints: Int!, singleColumn: Boolean): DataOrError
 }
+
+union DataOrError = Data | Error
 
 type ColumnDescription {
 	label: String!

--- a/apps/repo-server/src/csvImportWizard/CSVImportWizard.ts
+++ b/apps/repo-server/src/csvImportWizard/CSVImportWizard.ts
@@ -846,7 +846,7 @@ export class CSVImportWizard {
 							// If all rows contain an error (e.g., a column that cannot be parsed because it contains text)
 							// and the user imports them despite the warning, an empty Resource is created.
 							// An empty resource/table has little meaning. Therefore, this case is explicitly prohibited.
-							if (linesWrittenToOutputStream == 0) {
+							if (linesWrittenToOutputStream === 0) {
 								return resolve(
 									err({
 										error: `Not a single line could be interpreted correctly with the selected settings. This can happen, for example, if each individual line causes a warning because a column could not be interpreted.`,

--- a/apps/repo-server/src/graphql/generated/requests.ts
+++ b/apps/repo-server/src/graphql/generated/requests.ts
@@ -535,7 +535,7 @@ export type IResourceTabularData = INode &
 		 * If singleColumn is set to true only one y axis will be select and down sampled. Currently, an attempt is made to
 		 * select a specific column position in which the reactor temperature is often (but not always) located.
 		 */
-		downSampled?: Maybe<IData>;
+		downSampled?: Maybe<IDataOrError>;
 	};
 
 export type IResourceTabularDataProjectsArgs = {
@@ -782,6 +782,8 @@ export type IRowConnection = IConnection & {
 	count: Scalars["Int"];
 };
 
+export type IDataOrError = IData | IError;
+
 export type IData = {
 	__typename?: "Data";
 	x: IDataSeries;
@@ -795,6 +797,11 @@ export type IDataSeries = {
 	values: Array<Maybe<Scalars["Float"]>>;
 	device?: Maybe<IDevice>;
 	resourceId?: Maybe<Scalars["ID"]>;
+};
+
+export type IError = {
+	__typename?: "Error";
+	message: Scalars["String"];
 };
 
 export type IUserEdge = IEdge & {
@@ -977,6 +984,10 @@ export type IEdge_UserDataverseConnection = {
 	node: IUserDataverseConnection;
 };
 
+/**
+ * Represents the connection to a Dataverse instance
+ * NOTE: This is not a GraphQL connection
+ */
 export type IUserDataverseConnection = INode & {
 	__typename?: "UserDataverseConnection";
 	id: Scalars["ID"];
@@ -1656,11 +1667,6 @@ export type IAddDevicePayload = {
 };
 
 export type IDeviceOrSampleOrError = IDevice | ISample | IError;
-
-export type IError = {
-	__typename?: "Error";
-	message: Scalars["String"];
-};
 
 export type IAddDeviceDefinitionInput = {
 	parentDeviceDefinition?: InputMaybe<Scalars["ID"]>;

--- a/apps/repo-server/src/graphql/generated/schema.graphql
+++ b/apps/repo-server/src/graphql/generated/schema.graphql
@@ -356,7 +356,7 @@ type ResourceTabularData implements Node & Resource & ResourceTimed & HasProject
 	If singleColumn is set to true only one y axis will be select and down sampled. Currently, an attempt is made to
 	select a specific column position in which the reactor temperature is often (but not always) located.
 	"""
-	downSampled(dataPoints: Int!, singleColumn: Boolean): Data
+	downSampled(dataPoints: Int!, singleColumn: Boolean): DataOrError
 }
 
 interface HasMetadata {
@@ -556,6 +556,8 @@ type RowConnection implements Connection {
 	count: Int!
 }
 
+union DataOrError = Data | Error
+
 type Data {
 	x: DataSeries!
 	y: [DataSeries!]!
@@ -567,6 +569,10 @@ type DataSeries {
 	values: [Float]!
 	device: Device
 	resourceId: ID
+}
+
+type Error {
+	message: String!
 }
 
 type UserEdge implements Edge {
@@ -729,6 +735,10 @@ type Edge_UserDataverseConnection {
 	node: UserDataverseConnection!
 }
 
+"""
+Represents the connection to a Dataverse instance
+NOTE: This is not a GraphQL connection
+"""
 type UserDataverseConnection implements Node {
 	id: ID!
 	name: String!
@@ -1159,10 +1169,6 @@ type AddDevicePayload {
 }
 
 union DeviceOrSampleOrError = Device | Sample | Error
-
-type Error {
-	message: String!
-}
 
 input AddDeviceDefinitionInput {
 	parentDeviceDefinition: ID

--- a/apps/repo-server/src/graphql/resolvers/ResourceTabularData.ts
+++ b/apps/repo-server/src/graphql/resolvers/ResourceTabularData.ts
@@ -112,9 +112,14 @@ export const ResourceTabularData: IResolvers["ResourceTabularData"] = {
 		try {
 			const downsampled = await downsampling.requestGraph(request);
 
-			if (!downsampled) return undefined;
+			if (downsampled.type === "downsampling_pending" || downsampled.type === "temporary_error")
+				return undefined;
+			if (downsampled.type === "permanent_error") {
+				return { __typename: "Error", message: downsampled.message };
+			}
 
 			return {
+				__typename: "Data",
 				x: {
 					...downsampled.x,
 					device: downsampled.x.deviceId ? { id: downsampled.x.deviceId } : undefined,

--- a/apps/repo-server/src/services/downsampler/Downsampling.ts
+++ b/apps/repo-server/src/services/downsampler/Downsampling.ts
@@ -28,7 +28,7 @@ export interface IDownsamplingOptions {
 	datapoints: Threshold;
 
 	/**
-	 * If true, the requested graph is intended for the "Sparlines" feature
+	 * If true, the requested graph is intended for the "Sparklines" feature
 	 * 	- An attempt is made to select a particularly relevant column. Please note that the methodology is very
 	 * 		primitive/rudimentary and will be replaced by a user configuration at a later date.)
 	 * 	- Results are stored in the L1 cache. Since this mode is often used for lists of resources, it is advantageous

--- a/apps/repo-server/src/services/downsampler/Downsampling.ts
+++ b/apps/repo-server/src/services/downsampler/Downsampling.ts
@@ -27,7 +27,14 @@ export interface IDownsamplingOptions {
 
 	datapoints: Threshold;
 
-	keyIndicatorMode?: boolean; // Attempt to find key indicator which can be used as sparkline
+	/**
+	 * If true, the requested graph is intended for the "Sparlines" feature
+	 * 	- An attempt is made to select a particularly relevant column. Please note that the methodology is very
+	 * 		primitive/rudimentary and will be replaced by a user configuration at a later date.)
+	 * 	- Results are stored in the L1 cache. Since this mode is often used for lists of resources, it is advantageous
+	 * 	if the results are available quickly.
+	 */
+	keyIndicatorMode?: boolean;
 
 	startX?: number;
 	endX?: number;
@@ -41,10 +48,45 @@ interface IDownsamplingOptionsMerge {
 	offsets?: number[];
 }
 
+/**
+ * Downsampled data is used to represent the downsampled data for a resource.
+ * It contains the x-axis and y-axis data.
+ */
 export interface IDownsampledData {
+	type?: "data";
 	x: IDownsampledXColumn;
 	y: IDownsampledColumn[];
 }
+
+/**
+ * Permanent error is used to indicate that the downsampling failed and the result is cached.
+ * The result is cached as the downsampling task is not expected to succeed at a later point in time.
+ */
+export interface IDownsampledErrorPermanent {
+	type: "permanent_error";
+	message: string;
+}
+
+/**
+ * Temporary error is used to indicate that the downsampling failed.
+ * The result is not cached, and the next request will trigger a new downsampling task (which hopefully will succeed).
+ */
+export interface IDownsampledErrorTemporary {
+	type: "temporary_error";
+}
+
+export interface IDownsamplingPending {
+	type: "downsampling_pending";
+}
+
+// Level 1
+export type ShortTermCacheResult = LongTermCacheResult | IDownsampledErrorTemporary;
+
+// Level 2
+export type LongTermCacheResult =
+	| IDownsampledData
+	| IDownsampledErrorPermanent
+	| IDownsamplingPending;
 
 const THRESHOLDS = [18, 100, 150] as const;
 type Threshold = (typeof THRESHOLDS)[number];
@@ -73,10 +115,10 @@ const taskCache = new Set<DownsamplingCacheKey>();
 )
 export class Downsampling {
 	/**
-	 * Level 1 cache (fast, ephemeral
+	 * Level 1 cache (fast, ephemeral)
 	 * - Caches the downsampled data for each resource (mainly to reduce the load on the L2 cache
 	 *   for the resource list with many sparklines)
-	 * - Caches errors (if the downsampling fails) to prevent repeated attempts to downsample the
+	 * - Caches temporary errors (if the downsampling fails) to prevent repeated attempts to downsample the
 	 *   same data
 	 * - Backed by the file system of the apps container (which is ephemeral)
 	 * @private
@@ -112,13 +154,13 @@ export class Downsampling {
 
 	private async requestGraphFromCacheOnly(
 		options: IDownsamplingOptions
-	): Promise<IDownsampledData | undefined> {
+	): Promise<ShortTermCacheResult | undefined> {
 		const cacheKey = Downsampling.getCacheKey(options);
 
 		if (options.keyIndicatorMode) {
-			const data = await this.level1Cache.get(cacheKey, "IDownsampledDataOrError");
+			const data = await this.level1Cache.get(cacheKey, "ShortTermCacheResult");
 
-			if (data && !data?.data) {
+			if (data && data?.data === undefined) {
 				this.logger.debug(`Error value cached for ${options.resourceId}`);
 			}
 
@@ -127,14 +169,14 @@ export class Downsampling {
 			}
 		}
 
-		const cachedData = await this.level2Cache.get(cacheKey, "IDownsampledData");
-		if (cachedData) {
+		const cachedData = await this.level2Cache.get(cacheKey, "LongTermCacheResult");
+		if (cachedData?.data.type === "data" || cachedData?.data.type === "permanent_error") {
 			this.logger.debug("Downsampling Cache: HIT");
 
 			// Copy data from L2 to L1 cache (for data which is already downsampled)
 			if (options.keyIndicatorMode) {
 				await this.level1Cache.set(Downsampling.getCacheKey(options), {
-					type: "IDownsampledDataOrError",
+					type: "ShortTermCacheResult",
 					data: cachedData.data,
 				});
 			}
@@ -151,135 +193,188 @@ export class Downsampling {
 	 * will return a promise that resolves to undefined. The promise will also resolve to undefined if downsampling
 	 * fails.
 	 */
-	public async requestGraph(options: IDownsamplingOptions): Promise<IDownsampledData | undefined> {
+	public async requestGraph(options: IDownsamplingOptions): Promise<ShortTermCacheResult> {
 		const cached = await this.requestGraphFromCacheOnly(options);
-		if (cached) return cached;
+		if (cached?.type === "data" || cached?.type === "permanent_error") {
+			this.logger.debug(
+				`Returning cached downsampled data for ${options.resourceId}: ${JSON.stringify(cached)}`
+			);
+			return cached;
+		}
 
 		const cacheKey = Downsampling.getCacheKey(options);
 
 		// Check if downsampling is already in progress. We check here in addition to the check already performed in
 		// TaskDispatcher to avoid the expensive call to ram.getTabularData().
-		if (taskCache.has(cacheKey)) return;
+		if (taskCache.has(cacheKey)) {
+			this.logger.info(`Downsampling already in progress for ${options.resourceId}`);
+			return { type: "downsampling_pending" }; // Task was already created, return pending
+		}
 
 		const logger = this.logger.bind({ ...options });
 
-		const coreDownsample = async () => {
-			taskCache.add(cacheKey);
-			const resource = await this.el.one(this.schema.Resource, options.resourceId);
-			const tabularData = await this.ram.getTabularData(resource);
-			assert(resource.attachment.type === "TabularData");
-
-			// Index of x column
-			const x = resource.attachment.columns.findIndex(
-				({ independentVariables }) => independentVariables.length === 0
-			);
-			// Indices of y columns to be downsampled
-			const y: number[] = [];
-
-			assert(x > -1);
-
-			if (options.keyIndicatorMode) {
-				const indexOfReactorTempColumn = resource.attachment.columns.findIndex(
-					({ title }) => title === "Reaktor"
-				);
-
-				if (indexOfReactorTempColumn > -1) {
-					y.push(indexOfReactorTempColumn);
-				} else {
-					const lastColumnIndex = resource.attachment.columns.length - 1;
-					y.push(x !== lastColumnIndex ? lastColumnIndex : 0);
-				}
-			} else {
-				for (let i = 0; i < resource.attachment.columns.length; i++) {
-					const column = resource.attachment.columns[i];
-					if (column.independentVariables.length === 0) continue;
-
-					y.push(i);
-				}
-			}
-
-			const results = await this.td.dispatch("resources/downsample", {
-				input: {
-					prefix: this.repoInfo.repositoryName,
-					path: ResourceAttachmentManager.getPath(resource),
-					columns: { x, y },
-					numberColumns: tabularData.numColumns(),
-					numberRows: tabularData.numRows(),
-				},
-				threshold: options.datapoints,
-			});
-
-			if (!results) {
-				throw new Error("Unknown (check service logs)");
-			}
-
-			const { columns } = resource.attachment;
-
-			const xValues = results[0].map((v) => v[0]);
-
-			// Detect if X Axis is descending and reverse order of values in that case
-			const swapOrderForDescendingX = xValues[0] > xValues[xValues.length - 1];
-			if (swapOrderForDescendingX) {
-				xValues.reverse();
-			}
-
-			const printUnit = (unit: TUnit) => (unit === UnitlessMarker ? "Unitless" : unit);
-
-			const result: IDownsampledData = {
-				x: {
-					type: columns[x].type,
-					label: columns[x].title,
-					unit: printUnit(columns[x].unit),
-					values: xValues,
-				},
-				y: y.map((y, i) => {
-					const yValues = results[i].map((v) => v[1]);
-					if (swapOrderForDescendingX) {
-						yValues.reverse();
-					}
-
-					return {
-						deviceId: columns[y].deviceId,
-						resourceId: options.resourceId,
-						label: columns[y].title,
-						unit: printUnit(columns[y].unit),
-						values: yValues,
-					};
-				}),
-			};
-
-			logger.info(`Downsampling tasks finished. Writing into cache ${cacheKey}`);
-
-			if (options.keyIndicatorMode) {
-				await this.level1Cache.set(cacheKey, {
-					type: "IDownsampledDataOrError",
-					data: result,
-				});
-			}
-
-			await this.level2Cache.set(cacheKey, {
-				type: "IDownsampledData",
-				data: result,
-			});
-
-			this.sp.publish("downsampleDataBecameReady", {
-				resourceId: options.resourceId,
-				dataPoints: options.datapoints,
-				singleColumn: options.keyIndicatorMode,
-				resource: { id: options.resourceId },
-			});
-
-			// Remove the task from cache once we've successfully downsampled the data to avoid memory leaks.
-			taskCache.delete(cacheKey);
-		};
-
-		coreDownsample().catch((e) => {
+		this.createDownsamplingTask(options, cacheKey).catch((e) => {
 			const message = e instanceof Error ? e.message : "Unknown error";
 			logger.error(`Downsampling failed: ${message}`);
 
 			// Note that we don't remove the task in the event of an error. This is intentional, as we prevent
 			// downsampling the same data again that will fail anyway.
 		});
+		return { type: "downsampling_pending" }; // Task is being created, return pending
+	}
+
+	private async createDownsamplingTask(
+		options: IDownsamplingOptions,
+		cacheKey: DownsamplingCacheKey
+	) {
+		taskCache.add(cacheKey);
+		const resource = await this.el.one(this.schema.Resource, options.resourceId);
+		const tabularData = await this.ram.getTabularData(resource);
+		assert(resource.attachment.type === "TabularData");
+
+		// This check is here to prevent the server from crashing if a resource is empty
+		// This should not happen for future resources, but there are already existing resources without
+		// any content (with 0 rows).
+		if (tabularData.numRows() === 0) {
+			this.logger.info(`No rows found for resource ${options.resourceId}`);
+			const result = {
+				type: "permanent_error",
+				message:
+					"This resource does not contain any rows. Therefore, it is not possible to display a chart.",
+			} as const;
+			await this.finishProcessing({ downsamplingOptions: options, cacheKey, result });
+			return result;
+		}
+
+		// Index of x column
+		const x = resource.attachment.columns.findIndex(
+			({ independentVariables }) => independentVariables.length === 0
+		);
+		// Indices of y columns to be downsampled
+		const y: number[] = [];
+
+		assert(x > -1);
+
+		if (options.keyIndicatorMode) {
+			const indexOfReactorTempColumn = resource.attachment.columns.findIndex(
+				({ title }) => title === "Reaktor"
+			);
+
+			if (indexOfReactorTempColumn > -1) {
+				y.push(indexOfReactorTempColumn);
+			} else {
+				const lastColumnIndex = resource.attachment.columns.length - 1;
+				y.push(x !== lastColumnIndex ? lastColumnIndex : 0);
+			}
+		} else {
+			for (let i = 0; i < resource.attachment.columns.length; i++) {
+				const column = resource.attachment.columns[i];
+				if (column.independentVariables.length === 0) continue;
+
+				y.push(i);
+			}
+		}
+
+		if (y.length === 0) {
+			this.logger.info(`No y-axis columns found for resource ${options.resourceId}`);
+			const result = {
+				type: "permanent_error",
+				message:
+					"This resource does not contain any dependent columns (y-axis). Therefore, it is not possible to display a chart.",
+			} as const;
+			await this.finishProcessing({ downsamplingOptions: options, cacheKey, result });
+			return result;
+		}
+
+		const results = await this.td.dispatch("resources/downsample", {
+			input: {
+				prefix: this.repoInfo.repositoryName,
+				path: ResourceAttachmentManager.getPath(resource),
+				columns: { x, y },
+				numberColumns: tabularData.numColumns(),
+				numberRows: tabularData.numRows(),
+			},
+			threshold: options.datapoints,
+		});
+
+		if (!results) {
+			return { type: "temporary_error" };
+		}
+
+		const { columns } = resource.attachment;
+
+		const xValues = results[0].map((v) => v[0]);
+
+		// Detect if X Axis is descending and reverse order of values in that case
+		const swapOrderForDescendingX = xValues[0] > xValues[xValues.length - 1];
+		if (swapOrderForDescendingX) {
+			xValues.reverse();
+		}
+
+		const printUnit = (unit: TUnit) => (unit === UnitlessMarker ? "Unitless" : unit);
+
+		const result: IDownsampledData = {
+			x: {
+				type: columns[x].type,
+				label: columns[x].title,
+				unit: printUnit(columns[x].unit),
+				values: xValues,
+			},
+			y: y.map((y, i) => {
+				const yValues = results[i].map((v) => v[1]);
+				if (swapOrderForDescendingX) {
+					yValues.reverse();
+				}
+
+				return {
+					deviceId: columns[y].deviceId,
+					resourceId: options.resourceId,
+					label: columns[y].title,
+					unit: printUnit(columns[y].unit),
+					values: yValues,
+				};
+			}),
+		};
+
+		this.logger.info(`Downsampling tasks finished. Writing into cache`);
+
+		await this.finishProcessing({ downsamplingOptions: options, cacheKey, result });
+	}
+
+	/**
+	 * This function is called when a result is ready (i.e. downsample data or error).
+	 * It writes the result to the cache and notifies the client about the result.
+	 */
+	private async finishProcessing({
+		downsamplingOptions: options,
+		cacheKey,
+		result,
+	}: {
+		downsamplingOptions: IDownsamplingOptions;
+		cacheKey: DownsamplingCacheKey;
+		result: LongTermCacheResult;
+	}) {
+		if (options.keyIndicatorMode) {
+			await this.level1Cache.set(cacheKey, {
+				type: "ShortTermCacheResult",
+				data: { type: "data", ...result },
+			});
+		}
+
+		await this.level2Cache.set(cacheKey, {
+			type: "LongTermCacheResult",
+			data: { type: "data", ...result },
+		});
+
+		this.sp.publish("downsampleDataBecameReady", {
+			resourceId: options.resourceId,
+			dataPoints: options.datapoints,
+			singleColumn: options.keyIndicatorMode,
+			resource: { id: options.resourceId },
+		});
+
+		// Remove the task from cache once we've successfully downsampled the data to avoid memory leaks.
+		taskCache.delete(cacheKey);
 	}
 
 	public async requestGraphMerged(
@@ -300,7 +395,9 @@ export class Downsampling {
 					})
 				)
 			)
-		).filter(isNonNullish);
+		)
+			.filter(isNonNullish)
+			.filter((e): e is IDownsampledData => e.type === "data");
 
 		// It is possible that all requested resources aren't downsampled yet
 		// In this case we return an empty array

--- a/apps/repo-server/src/services/downsampler/__tests__/Downsampling.spec.ts
+++ b/apps/repo-server/src/services/downsampler/__tests__/Downsampling.spec.ts
@@ -153,7 +153,7 @@ describe("Downsampling service", () => {
 		// Get the same data again. This time it should be returned instead of undefined
 		const graph2 = await downsampling.requestGraph({ resourceId: resource.id, datapoints: 18 });
 
-		expect(graph2.type === "data");
+		expect(graph2.type).toBe("data");
 		expect(graph2).toBeDefined();
 
 		// Make sure the task dispatcher was correctly called

--- a/apps/repo-server/src/services/downsampler/__tests__/Downsampling.spec.ts
+++ b/apps/repo-server/src/services/downsampler/__tests__/Downsampling.spec.ts
@@ -1,3 +1,5 @@
+import assert from "assert";
+
 import type { MockInstance } from "vitest";
 import { describe, expect, test, vi } from "vitest";
 
@@ -11,6 +13,7 @@ import { SubscriptionPublisher } from "~/apps/repo-server/src/graphql/context/Su
 import { EntityLoader } from "~/apps/repo-server/src/services/EntityLoader";
 import { createTestDb } from "~/apps/repo-server/testUtils";
 import { DrizzleSchema } from "~/drizzle/DrizzleSchema";
+import { assertDefined } from "~/lib/assert";
 import { createIDatetime } from "~/lib/createDate";
 import { EntityFactory } from "~/lib/database/EntityFactory";
 import type { IDeviceId } from "~/lib/database/Ids";
@@ -21,17 +24,32 @@ import type { StorageEngine } from "~/lib/storage-engine";
 import type { Writable } from "~/lib/streams";
 import { TabularData } from "~/lib/tabular-data";
 
-const createColumnDescription = (independent: boolean): ITabularDataColumnDescription => ({
+/**
+ * Creates a column description with the given independent index.
+ * If the independent index is -1, the column is independent.
+ * @param independentIndex
+ */
+const createColumnDescription = (independentIndex: number): ITabularDataColumnDescription => ({
 	type: "number",
 	deviceId: "123" as IDeviceId,
 	description: "",
 	unit: "",
 	title: "",
 	columnId: "",
-	independentVariables: independent ? [] : [0],
+	independentVariables: independentIndex < 0 ? [] : [independentIndex],
 });
 
-const createTable = async (ef: EntityFactory, sto: StorageEngine) => {
+const createTable = async ({
+	ef,
+	sto,
+	containsIndependent = true,
+	fillTable: fillTableOption = true,
+}: {
+	ef: EntityFactory;
+	sto: StorageEngine;
+	containsIndependent?: boolean;
+	fillTable?: boolean;
+}) => {
 	const resource = ef.create("Resource", {
 		name: "Test",
 		attachment: {
@@ -40,9 +58,9 @@ const createTable = async (ef: EntityFactory, sto: StorageEngine) => {
 			begin: createIDatetime(new Date(0)),
 			end: createIDatetime(new Date(1)),
 			columns: [
-				createColumnDescription(true),
-				createColumnDescription(false),
-				createColumnDescription(false),
+				createColumnDescription(-1),
+				createColumnDescription(containsIndependent ? 0 : -1),
+				createColumnDescription(containsIndependent ? 0 : -1),
 			],
 			hash: {
 				type: "sha256",
@@ -54,10 +72,40 @@ const createTable = async (ef: EntityFactory, sto: StorageEngine) => {
 	const path = ResourceAttachmentManager.getPath(resource.id);
 
 	const stream = TabularData.createWriteStream(sto, path);
-	await fillTable(stream);
+	if (fillTableOption) {
+		await fillTable(stream);
+	}
 
 	return resource;
 };
+
+async function spy({
+	td,
+	sp,
+	dispatchResult,
+}: {
+	td: TaskDispatcher;
+	sp: SubscriptionPublisher;
+	dispatchResult?: [number, number][][];
+}) {
+	let spy1: MockInstance<any[]> | undefined;
+	if (dispatchResult) {
+		// Configure the task dispatcher to return a dummy data set as a downsampling result.
+		spy1 = vi.spyOn(td, "dispatch").mockImplementation(() => {
+			return Promise.resolve(dispatchResult);
+		});
+	}
+
+	// Create a promise that resolves when the event is emitted
+	let spy2: MockInstance<any[]> | undefined;
+	const eventResult = await new Promise((resolve) => {
+		spy2 = vi.spyOn(sp, "publish").mockImplementation((a, b) => {
+			resolve([a, b]);
+		});
+	});
+
+	return { eventResult, spy1, spy2 };
+}
 
 describe("Downsampling service", () => {
 	async function setup() {
@@ -67,8 +115,6 @@ describe("Downsampling service", () => {
 		sc.set(new RepositoryInfo("test"));
 
 		const sto: StorageEngine = sc.set(new FileSystemStorageEngine(await mkdirTmp()));
-		const stream = TabularData.createWriteStream(sto, "temp", 3);
-		await fillTable(stream);
 
 		return {
 			sto,
@@ -92,40 +138,93 @@ describe("Downsampling service", () => {
 			schema: { Resource },
 		} = await setup();
 
-		// Configure the task dispatcher to return a dummy data set as a downsampling result.
-		const spy1 = vi
-			.spyOn(td, "dispatch")
-			.mockImplementation(() => Promise.resolve([[[0, 0]], [[0, 0]]]));
-
-		// Create a promise that resolves when the event is emitted
-		let spy2: MockInstance<any[]> | undefined;
-		const promise = new Promise((resolve) => {
-			spy2 = vi.spyOn(sp, "publish").mockImplementation(resolve);
-		});
-
-		const resource = await createTable(ef, sto);
+		const resource = await createTable({ ef: ef, sto: sto });
 		await el.insert(Resource, resource);
 		const graph = await downsampling.requestGraph({ resourceId: resource.id, datapoints: 18 });
 
-		// Should return undefined because downsampling has not completed yet
-		expect(graph).toBeUndefined();
+		// Should return "downsampling_pending" because downsampling has not completed yet
+		expect(graph.type).toBe("downsampling_pending");
 
 		// Wait for the event to be emitted. After this time, the file should be accessible when we call `requestGraph`
 		// again.
-		await promise;
+		const { spy1, spy2, eventResult } = await spy({ td, sp, dispatchResult: [[[0, 0]], [[0, 0]]] });
+		expect(eventResult).toBeDefined();
 
 		// Get the same data again. This time it should be returned instead of undefined
 		const graph2 = await downsampling.requestGraph({ resourceId: resource.id, datapoints: 18 });
 
+		expect(graph2.type === "data");
 		expect(graph2).toBeDefined();
 
 		// Make sure the task dispatcher was correctly called
 		expect(spy1).toHaveBeenCalledTimes(1);
+		assertDefined(spy1);
 		expect(spy1.mock.calls[0][0]).toBe("resources/downsample");
 
 		// Make sure the correct event was emitted
 		expect(spy2).toHaveBeenCalledTimes(1);
 		expect(spy2?.mock.calls[0][0]).toBe("downsampleDataBecameReady");
+	});
+
+	test("returns error if dependent variables are missing in resource", async () => {
+		const {
+			sto,
+			el,
+			ef,
+			downsampling,
+			td,
+			sp,
+			schema: { Resource },
+		} = await setup();
+
+		const resource = await createTable({ ef: ef, sto: sto, containsIndependent: false });
+		await el.insert(Resource, resource);
+		const graph = await downsampling.requestGraph({ resourceId: resource.id, datapoints: 18 });
+
+		// Should return "downsampling_pending" because downsampling has not completed yet
+		expect(graph.type).toBe("downsampling_pending");
+
+		// Wait for the event to be emitted. After this time, the file should be accessible when we call `requestGraph`
+		// again.
+		await spy({ td, sp });
+
+		const result = await downsampling.requestGraph({ resourceId: resource.id, datapoints: 18 });
+		expect(result.type).toBe("permanent_error");
+		assert(result.type === "permanent_error");
+		expect(result.message).toMatch("not contain any dependent columns");
+	});
+
+	test("returns error if resource is empty", async () => {
+		const {
+			sto,
+			el,
+			ef,
+			downsampling,
+			td,
+			sp,
+			schema: { Resource },
+		} = await setup();
+
+		const resource = await createTable({
+			ef: ef,
+			sto: sto,
+			containsIndependent: false,
+			fillTable: false,
+		});
+		await el.insert(Resource, resource);
+		const graph = await downsampling.requestGraph({ resourceId: resource.id, datapoints: 18 });
+
+		// Should return "downsampling_pending" because downsampling has not completed yet
+		expect(graph.type).toBe("downsampling_pending");
+
+		// Wait for the event to be emitted. After this time, the file should be accessible when we call `requestGraph`
+		// again.
+		await spy({ td, sp });
+
+		const result = await downsampling.requestGraph({ resourceId: resource.id, datapoints: 18 });
+		expect(result.type).toBe("permanent_error");
+		assert(result.type === "permanent_error");
+		expect(result.message).toMatch("not contain any rows");
 	});
 });
 

--- a/apps/repo-server/src/storage/keyValueDatabase/KeyValueDatabase.ts
+++ b/apps/repo-server/src/storage/keyValueDatabase/KeyValueDatabase.ts
@@ -1,6 +1,9 @@
 import type { Promisable } from "type-fest";
 
-import type { IDownsampledData } from "../../services/downsampler/Downsampling";
+import type {
+	LongTermCacheResult,
+	ShortTermCacheResult,
+} from "../../services/downsampler/Downsampling";
 
 /**
  * Storage abstraction for various possible backends which provide a way to persist Key-Value pairs.
@@ -37,11 +40,11 @@ export abstract class KeyValueDatabase {
  */
 export type IKeyValueDocument =
 	| {
-			type: "IDownsampledData";
-			data: IDownsampledData;
+			type: "ShortTermCacheResult";
+			data: ShortTermCacheResult;
 	  }
 	| {
-			type: "IDownsampledDataOrError";
-			data: IDownsampledData | undefined;
+			type: "LongTermCacheResult";
+			data: LongTermCacheResult;
 	  }
 	| { type: "string"; data: string };

--- a/apps/repo-server/src/storage/keyValueDatabase/__tests__/KeyValueDatabaseStorageEngineBackend.spec.ts
+++ b/apps/repo-server/src/storage/keyValueDatabase/__tests__/KeyValueDatabaseStorageEngineBackend.spec.ts
@@ -25,7 +25,7 @@ describe("KeyValueDatabaseStorageEngine", () => {
 
 		expect(await kvDatabase.get(newKey)).toStrictEqual(newValue);
 
-		expect(await kvDatabase.get(newKey, "IDownsampledData")).toBeUndefined();
+		expect(await kvDatabase.get(newKey, "ShortTermCacheResult")).toBeUndefined();
 	});
 
 	test("supports updates", async () => {


### PR DESCRIPTION
A typical case where Adacta cannot generate a chart is when there are no dependencies between the columns (all columns are independent). Another case occurs when a resource does not contain any rows (if each row causes a parse warning and the user continues with the import anyway).

- Downsampling:
  - Introduced distinct error types (`permanent_error`, `temporary_error`, and `downsampling_pending`) for better handling of downsampling failures.
  - Adjusted cache handling for downsampled data and related errors.
  - Ensured proper checks for empty resources or missing dependent columns during downsampling.
- ImportWizard: Detect when a resource would be created that has no lines and abort the import.