### PR TITLE
Add proper warning when removing components

### DIFF
--- a/apps/desktop-app/src/components/device/modals/RemoveComponentModal.tsx
+++ b/apps/desktop-app/src/components/device/modals/RemoveComponentModal.tsx
@@ -3,12 +3,14 @@ import assert from "assert";
 import {
 	EuiButton,
 	EuiButtonEmpty,
+	EuiCallOut,
 	EuiFormRow,
 	EuiModal,
 	EuiModalBody,
 	EuiModalFooter,
 	EuiModalHeader,
 	EuiModalHeaderTitle,
+	EuiSpacer,
 	EuiSuperSelect,
 } from "@elastic/eui";
 import React, { useState } from "react";
@@ -72,6 +74,16 @@ export function RemoveComponentModal(props: IProps) {
 
 	const { device } = data.repository;
 
+	const componentsInSlot = [...device.componentsInSlot].sort(
+		(a, b) => createDate(a.installDate).getTime() - createDate(b.installDate).getTime()
+	);
+
+	// Get names for the slot and the component witthin
+	const currentComponent = componentsInSlot.slice(-1)[0];
+	assert(currentComponent.component.__typename !== "%other");
+	const componentName = currentComponent.component.name;
+	const slotName = props.pathFromTopLevelDevice.slice(-1)[0];
+
 	return (
 		<EuiModal maxWidth={"90vw"} onClose={props.onClose} style={{ minWidth: "600px" }}>
 			<EuiModalHeader>
@@ -81,7 +93,7 @@ export function RemoveComponentModal(props: IProps) {
 				<EuiFormRow fullWidth label="Usage to remove" display="columnCompressed">
 					<EuiSuperSelect
 						fullWidth
-						options={device.componentsInSlot.map(({ component, installDate, removeDate }, i) => {
+						options={componentsInSlot.map(({ component, installDate, removeDate }, i) => {
 							assert(component.__typename !== "%other");
 							return {
 								value: String(i),
@@ -98,13 +110,38 @@ export function RemoveComponentModal(props: IProps) {
 						hasDividers
 					/>
 				</EuiFormRow>
+				<EuiSpacer />
+				<EuiCallOut
+					color={"danger"}
+					title={"This change alters the timeline"}
+					style={{ width: 600 }}
+				>
+					<p>
+						This action will modify the timeline and should only be performed if the intention is to
+						correct an error in the history.
+					</p>
+					<p>
+						The removal or installation of a device or sample should be carried out using either:
+					</p>
+					<ul>
+						<li>
+							Swap <strong>{componentName}</strong> in <strong>{slotName}</strong> slot - when
+							replacing a device or sample with another
+						</li>
+						<li>
+							Edit <strong>{componentName}</strong> usage in <strong>{slotName}</strong> slot - when
+							adjusting or correcting usage details (e.g. setting the removal date)
+						</li>
+					</ul>
+				</EuiCallOut>
 			</EuiModalBody>
 			<EuiModalFooter>
 				<EuiButtonEmpty onClick={props.onClose}>Cancel</EuiButtonEmpty>
 				<EuiButton
+					color={"danger"}
 					fill
 					onClick={() => {
-						const componentInSlot = device.componentsInSlot[usageIndex];
+						const componentInSlot = componentsInSlot[usageIndex];
 						assert(componentInSlot.component.__typename !== "%other");
 						props.onSubmit(
 							componentInSlot.component.id,


### PR DESCRIPTION
The “Remove” function is generally only needed in special cases. The new warning text highlights exactly what the function does and explains when it makes sense to use it and when to use other functions instead.